### PR TITLE
Fixing issue where last char is chopped off in a greedy match all.

### DIFF
--- a/action_plugins/text_parser.py
+++ b/action_plugins/text_parser.py
@@ -377,7 +377,7 @@ class ActionModule(ActionBase):
 
         context_end = re.search(context_end_re, contents[end:])
         if not context_end:
-            return (string_start, -1)
+            return (string_start, None)
 
         if include_end:
             string_end = end + context_end.end()


### PR DESCRIPTION
Using the pattern_match with match_all and match_greedy, the last character of the last match would be chopped off because of the -1 that was returning. Returning `None` avoids that since the _greedy_match function checks for `None` already.