### PR TITLE
Add textfsm module to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ None
 ## Modules
 The following is a list of modules that are provided by this role.
 
-* text_parser [[source]](library/text_parser.py)
-* get_config [[source]](library/get_config.py)
 * cli_get [[source]](library/cli_get.py)
+* get_config [[source]](library/get_config.py)
+* text_parser [[source]](library/text_parser.py)
+* textfsm [[source]](library/textfsm.py)
 
 ## Plugins
 The following is a list of plugins that are provided by this role.


### PR DESCRIPTION
Add missing **textfsm** module to README.md.