### PR TITLE
Handles loops on nested pattern_groups

### DIFF
--- a/action_plugins/text_parser.py
+++ b/action_plugins/text_parser.py
@@ -208,7 +208,14 @@ class ActionModule(ActionBase):
                 raise AnsibleError('invalid directive specified')
 
             if 'pattern_group' in task:
-                res = self.do_pattern_group(task['pattern_group'])
+                if loop:
+                    res = list()
+                    for loop_item in loop:
+                        self.ds[loop_var] = loop_item
+                        res.append(self.do_pattern_group(task['pattern_group']))
+                else:
+                    res = self.do_pattern_group(task['pattern_group'])
+
                 if res:
                     results.append(res)
                 if register:

--- a/action_plugins/text_parser.py
+++ b/action_plugins/text_parser.py
@@ -208,7 +208,7 @@ class ActionModule(ActionBase):
                 raise AnsibleError('invalid directive specified')
 
             if 'pattern_group' in task:
-                if loop:
+                if loop and isinstance(loop, collections.Iterable) and not isinstance(loop, string_types):
                     res = list()
                     for loop_item in loop:
                         self.ds[loop_var] = loop_item


### PR DESCRIPTION
Now should be able to have nested pattern_groups with loops. 

```
- name: first group
  pattern_group:
    - name: match name
      pattern_match:
        regex: "name (\\S+)"
        contents: "{{ item }}"
      register: name

    - name: inner pattern_group with loop
      pattern_group:
        - name: match id
          pattern_match:
            regex: "^vlan (\\S+)"
            contents: "{{ testing }}"
          register: inner_var
      loop: "{{ other_context }}"
      loop_control:
        loop_var: testing
      register: testing_loop

  loop: "{{ context }}"
  register: test_nested
```