### PR TITLE
WIP: Add ansible-role-functional-centos-7 job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,7 +1,27 @@
+- nodeset:
+    name: centos-7
+    nodes:
+      - name: centos-7
+        label: dib-centos-7
+
+- job:
+    name: ansible-role-functional-base
+    abstract: true
+    parent: tox
+    description: |
+      Run functional functional tests for ansible-role projects.
+
+      Uses tox with the ``functional`` environment.
+    pre-run: tests/playbooks/ansible-role-functional/pre.yaml
+    run: tests/playbooks/tox-with-sudo/run.yaml
+    vars:
+      tox_envlist: functional
+
+- job:
+    name: ansible-role-functional-centos-7
+    parent: ansible-role-functional-base
+
 - project:
     check:
       jobs:
-        - tox-linters
-    gate:
-      jobs:
-        - tox-linters
+        - ansible-role-functional-centos-7

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
 flake8
+ansible

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ../..

--- a/tests/playbooks/ansible-role-functional/pre.yaml
+++ b/tests/playbooks/ansible-role-functional/pre.yaml
@@ -1,0 +1,11 @@
+- hosts: all
+  name: Set up SSH login
+  tasks:
+    - name: Allow ssh login into localhost
+      shell:
+        cmd: |
+          # Allow user to ssh into localhost
+          ssh-keygen -f ~/.ssh/id_rsa -N ""
+          cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+          ssh-keyscan localhost >> ~/.ssh/known_hosts
+          ssh-keyscan 127.0.0.1 >> ~/.ssh/known_hosts

--- a/tests/playbooks/tox-with-sudo/run.yaml
+++ b/tests/playbooks/tox-with-sudo/run.yaml
@@ -1,0 +1,3 @@
+- hosts: all
+  roles:
+    - tox

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
-  remote_user: root
+  vars:
+    rolename: "{{ lookup('pipe', 'pwd') | dirname | basename }}"
   roles:
-    - network-engine
+    - "{{ rolename }}"

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,16 @@ skipsdist = True
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
 
+[testenv:functional]
+commands =
+  ansible-playbook -i tests/inventory tests/test.yaml
+passenv =
+  HOME
+  USER
+setenv =
+  ANSIBLE_CONFIG = {toxinidir}/tests/ansible.cfg
+  PYTHONUNBUFFERED = 1
+
 [testenv:venv]
 commands = {posargs}
 


### PR DESCRIPTION
Add an example ansible functional jobs using tests from the test
folder. This leverages tox to allow a user to run these locally if
needed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>