### PR TITLE
fix do_pattern_match when using loop

### DIFF
--- a/action_plugins/text_parser.py
+++ b/action_plugins/text_parser.py
@@ -289,7 +289,7 @@ class ActionModule(ActionBase):
             raise AnsibleError('parser expected %s, got %s' % (network_os, self.ds['ansible_network_os']))
 
     def do_pattern_match(self, regex, contents=None, match_all=None, match_until=None, match_greedy=None):
-        contents = contents or self.template("{{ contents }}", self.ds)
+        contents = self.template(contents, self.ds) or self.template("{{ contents }}", self.ds)
         parser = parser_loader.get('pattern_match', contents)
         return parser.match(regex, match_all, match_until, match_greedy)
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

**Summary:**

When using `loop`, `{{ item }}` is passed as the string itself to contents, which does not pass the actual contents to patter_match plugin resulting no regex match, hence returning null value.

**Component name:**
``` 
action_plugins/text_parser.py
```
