### PR TITLE
textfsm facts fix

### DIFF
--- a/action_plugins/textfsm.py
+++ b/action_plugins/textfsm.py
@@ -61,14 +61,16 @@ class ActionModule(ActionBase):
             except Exception as exc:
                 raise AnsibleError(str(exc))
 
-            facts = {}
+            final_facts = []
             for item in fsm_results:
+                facts = {}
                 facts.update(dict(zip(re_table.header, item)))
+                final_facts.append(facts)
 
             if name:
-                result['ansible_facts'] = {name: facts}
+                result['ansible_facts'] = {name: final_facts}
             else:
-                result['ansible_facts'] = facts
+                result['ansible_facts'] = {}
 
         finally:
             self._remove_tmp_path(self._connection._shell.tmpdir)

--- a/library/textfsm.py
+++ b/library/textfsm.py
@@ -49,7 +49,7 @@ options:
     description:
       - The C(name) argument is used to define the top-level fact name to
         hold the output of the parser.  If this argument is not provided,
-        the output from parsing will be added as top level facts.
+        the output from parsing will not be exported.
     required: false
     default: null
 '''


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

Fixes https://github.com/ansible-network/network-engine/issues/14

**Summary**
Current code returns only the last dictionary entry as ansible_facts and ignores rest of the facts.
The way to fix the above issue is to return output/facts as list to a key (arg `name`) to  `ansible_facts` like `text_parser` engine. 

Return `ansible_facts` when `name` parameter is provided for textfsm engine.
Otherwise do not export output from parsing.

With this FIX
**1.**
When the following playbook is run:
```
    - name: Parse from contents and generate json structure
      textfsm:
        file: parsers/nxos/show_vlan.yaml
        contents: "{{ lookup('file', 'output/nxos/show_vlan.txt') }}"
```
Result:
```
ok: [nxos9k-02] => {                                
    "ansible_facts": {},                            
    "changed": false                                
} 
```

**2.**
When the following playbook is run:
```
    - name: Parse from contents and generate json structure
      textfsm:
        file: parsers/nxos/show_vlan.yaml
        contents: "{{ lookup('file', 'output/nxos/show_vlan.txt') }}"
        name: output
```

Result:
```
ok: [nxos9k-02] => {
    "ansible_facts": {
        "nxos_vlan": [
            {
                "NAME": "default", 
                "STATE": "active", 
                "VLAN_ID": "1"
            }, 
            {
                "NAME": "app02", 
                "STATE": "active", 
                "VLAN_ID": "102"
            }, 
            {
                "NAME": "app03", 
                "STATE": "active", 
                "VLAN_ID": "103"
            }, 
            {
                "NAME": "test1001", 
                "STATE": "active", 
                "VLAN_ID": "1001"
            }, 
            {
                "NAME": "test", 
                "STATE": "active", 
                "VLAN_ID": "2096"
            }
        ]
    }, 
    "changed": false
}
```