### PR TITLE
remove unnecessary code from export register logic

### DIFF
--- a/action_plugins/text_parser.py
+++ b/action_plugins/text_parser.py
@@ -162,12 +162,7 @@ class ActionModule(ActionBase):
                     elif res and register:
                         self.ds[register] = res
                         if export:
-                            if register:
-                                facts[register] = res
-                            else:
-                                for r in to_list(res):
-                                    for k, v in iteritems(r):
-                                        facts.update({to_text(k): v})
+                            facts[register] = res
 
         result.update({
             'ansible_facts': facts,


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

**Summary**

Since `register` check is already before export, `elif res and register`, no need for nested condition.
We do not return facts if export is not true.