### PR TITLE
Sanity fixes (Python3, Docs)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,10 @@ that need to be done.
 module can be contributed directly to Ansible core, distributed through Ansible
 Galaxy or added to this role.
 
-2) Optional Step: If adding the module code directly to this role, add the module
+2) (Optional) If adding the module code directly to this role, add the module
 to `library/`
 
-3) Optional Steps: If the new platform module is distributed through another Galaxy
+3) (Optional) If the new platform module is distributed through another Galaxy
 role, please update [README](README.md) Dependencies section to include the
 name of the Galaxy role that includes the module.
 
@@ -80,5 +80,4 @@ issue](../../issues)
 ## Contact
 
 * [#ansible-network IRC channel](https://webchat.freenode.net/?channels=ansible-network) on Freenode.net
-
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,23 +19,21 @@ that need to be done.
 module can be contributed directly to Ansible core, distributed through Ansible
 Galaxy or added to this role.
 
-2) Optional Steps
-
-a) If adding the module code directly to this role, add the module
+2) Optional Step: If adding the module code directly to this role, add the module
 to `library/`
 
-b) If the new platform module is distributed through another Galaxy
+3) Optional Steps: If the new platform module is distributed through another Galaxy
 role, please update [README](README.md) Dependencies section to include the
 name of the Galaxy role that includes the module.
 
-3) Once the module has been created, the add a new task in `tasks/` for the
+4) Once the module has been created, the add a new task in `tasks/` for the
 specific platform to be supported.  Use any of the existing platform
 implementations as a guide.
 
-4) (Optional) If a configuration parameter is not supported, then the
+5) (Optional) If a configuration parameter is not supported, then the
 implementation in tasks should detect that and provide a warning message.
 
-5) Update the `meta/main.yaml` file to add the newly provided platform to
+6) Update the `meta/main.yaml` file to add the newly provided platform to
 the `platforms` meta data.
 
 ### Adding platform specific arguments
@@ -70,7 +68,7 @@ create a file in the docs directory using GitHub Markdown.  The file name
 should be the platform name.
 
 For instance, let's assume we want to create implementation nodes for a
-fictitious platform call `foo`.  Create a new file in docs/ called `foo.md` and
+fictitious platform call `foo`.  Create a new file `docs/foo.md` and
 then add a link to [README](README.md) pointing to `docs/foo.md` in the `PLATFORM
 NOTES` section.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,17 @@
 # Developer Guide
-This role is developed and mantained by the Ansible Network Working Group.
-Contributions to this role are welcomed.  This document will provide inviduals
+
+This role is developed and maintained by the Ansible Network Working Group.
+Contributions to this role are welcomed.  This document will provide individuals
 with information about how to contribute to the further development of this
 role.
 
 ## Contributing
-There are many ways you can contribute to this role.  Adding new artifacts such
+
+There are many ways you can contribute to this role.  Adding new artefacts such
 as modules and plugins, testing and/or reviewing and updating documentation.
 
 ### Adding support for a new platform
+
 To add support for a new platform to this role, there are a couple of things
 that need to be done.
 
@@ -19,33 +22,34 @@ Galaxy or added to this role.
 2) Optional Steps
 
 a) If adding the module code directly to this role, add the module
-to ```library/```
+to `library/`
 
 b) If the new platform module is distributed through another Galaxy
-role, please update [README](README.md) Dependencies section to include the 
+role, please update [README](README.md) Dependencies section to include the
 name of the Galaxy role that includes the module.
 
-3) Once the module has been created, the add a new task in ```tasks/``` for the
+3) Once the module has been created, the add a new task in `tasks/` for the
 specific platform to be supported.  Use any of the existing platform
 implementations as a guide.
 
 4) (Optional) If a configuration parameter is not supported, then the
 implementation in tasks should detect that and provide a warning message.
 
-5) Update the ```meta/main.yaml``` file to add the newly provided platform to
-the ```platforms``` meta data.
+5) Update the `meta/main.yaml` file to add the newly provided platform to
+the `platforms` meta data.
 
 ### Adding platform specific arguments
+
 Sometimes there is a need to add platform specific arguments to a role for use
 by a platform specific module.  This can be accomplished by adding the adding
-the arguments under a platform specific key.  
+the arguments under a platform specific key.
 
 Note: It is the responsibility of the task writer to handle the implementation
-of the platform specific arguments.  
+of the platform specific arguments.
 
 Here is an example that implements a platform specific argument:
 
-```
+```yaml
 tasks:
   - name: configure network device resource
     include_role:
@@ -58,11 +62,12 @@ tasks:
 ```
 
 ### Adding documentation for a platform specific implementation
+
 While not required, there are times when providing implementation nodes are
 advantageous to instructing the playbook writer how to implement platform
 specific arguments.  In order to provide platform specific documentation,
-create a file in the docs directory using Github Markdown.  The file name
-should be the platform name. 
+create a file in the docs directory using GitHub Markdown.  The file name
+should be the platform name.
 
 For instance, let's assume we want to create implementation nodes for a
 fictitious platform call `foo`.  Create a new file in docs/ called `foo.md` and
@@ -70,10 +75,12 @@ then add a link to [README](README.md) pointing to `docs/foo.md` in the `PLATFOR
 NOTES` section.
 
 ## Bug Reporting
-If you have found a bug in the with the current role please open a [Github
-issue](../../issues)  
+
+If you have found a bug in the with the current role please open a [GitHub
+issue](../../issues)
 
 ## Contact
+
 * [#ansible-network IRC channel](https://webchat.freenode.net/?channels=ansible-network) on Freenode.net
 
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,56 @@
 # network-engine
-This role provides the foundation for building network roles by providing 
+
+This role provides the foundation for building network roles by providing
 modules and plugins that are common to all Ansible Network roles.  All of
-the artifacts in this role can be used independent of the platform that is 
+the artifacts in this role can be used independent of the platform that is
 being managed.
 
-Any open bugs and/or feature requests are tracked in [Github issues](../../issues).
+Any open bugs and/or feature requests are tracked in [GitHub issues](../../issues).
 
 Interested in contributing to this role, please see [CONTRIBUTING](CONTRIBUTING.md)
 
 ## Requirements
+
 None
 
 ## Tasks
+
 The following are the available tasks provided by this role for use in
 playbooks.
 
 None
 
 ## Variables
+
 The following are the list of variables this role accepts
 
 None
 
 ## Modules
+
 The following is a list of modules that are provided by this role.
 
-* cli [[source]](library/cli.py)
-* get_config [[source]](library/get_config.py)
-* text_parser [[source]](library/text_parser.py)
-* textfsm [[source]](library/textfsm.py)
+* `cli` [[source]](library/cli.py)
+* `get_config` [[source]](library/get_config.py)
+* `text_parser` [[source]](library/text_parser.py)
+* `textfsm` [[source]](library/textfsm.py)
 
 ## Plugins
+
 The following is a list of plugins that are provided by this role.
 
 None
 
 ## Dependencies
+
 The following is the list of dependencies on other roles this role requires.
 
 None
 
 ## License
+
 GPLv3
 
 ## Author Information
+
 Ansible Network Engineering Team

--- a/action_plugins/cli.py
+++ b/action_plugins/cli.py
@@ -4,6 +4,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import json
 
 from ansible.plugins.action import ActionBase

--- a/action_plugins/text_parser.py
+++ b/action_plugins/text_parser.py
@@ -4,6 +4,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import os
 import sys
 import collections

--- a/docs/directives/parser_directives.md
+++ b/docs/directives/parser_directives.md
@@ -20,7 +20,7 @@ returned to the Ansible facts system.
 ## Parser language
 
 The parser format uses YAML formatting, providing an ordered list of directives
-to be performed on the contents (provided by the module argument).  The overall
+to be performed on the content (provided by the module argument).  The overall
 general structure of a directive is as follows:
 
 ```yaml
@@ -121,7 +121,7 @@ Ansible fact in mentioned format. The `export_as` option can be used to define t
 
 Sometimes it is necessary to loop over a directive in order to process values.
 Using the `loop` option, the parser will iterate over the directive and
-provide each of the values provided by the loop contents to the directive for
+provide each of the values provided by the loop content to the directive for
 processing.
 
 Access to the individual items is the same as it would be for Ansible
@@ -167,7 +167,7 @@ the `when` conditional as such:
 
 ## Directives
 
-The directives perform actions on the contents using regular expressions to
+The directives perform actions on the content using regular expressions to
 extract various values.  Each directive provides some additional arguments that
 can be used to perform its operation.
 

--- a/docs/directives/parser_directives.md
+++ b/docs/directives/parser_directives.md
@@ -1,28 +1,29 @@
-CLI Parser Directives
-=====================
-The ```text_parser``` module is a module that can be used to parse the results of
+# CLI Parser Directives
+
+The `text_parser` module is a module that can be used to parse the results of
 text strings into Ansible facts.  The primary motivation for developing the
-```text_parser``` module is to convert structured ASCII text output (such as
-those returned from network devices) into  JSON data structures sutable to be 
+`text_parser` module is to convert structured ASCII text output (such as
+those returned from network devices) into  JSON data structures suitable to be
 used as host facts.
 
 The parser file format is loosely based on the Ansible playbook directives
 language.  It uses the Ansible directive language to ease the transition from
-writing playbooks to writing parsers.  However, parsers developed using this 
+writing playbooks to writing parsers.  However, parsers developed using this
 module are not written directly into the playbook, but are a separate file
 called from playbooks.  This is done for a variety of reasons but most notably
-to keep separation from the parsing logical and playbook execution. 
+to keep separation from the parsing logical and playbook execution.
 
-The ```text_parser``` works based on a set of directives that perform actions
+The `text_parser` works based on a set of directives that perform actions
 on structured data with the end result being a valid JSON structure that can be
 returned to the Ansible facts system.
 
-## Parser language 
-The parser format uses YAML formatting, providing an ordered list of directives 
-to be performed on the content (provided by the module argument).  The overall 
+## Parser language
+
+The parser format uses YAML formatting, providing an ordered list of directives
+to be performed on the contents (provided by the module argument).  The overall
 general structure of a directive is as follows:
 
-```
+```yaml
 - name: some description name of the task to be performed
   directive:
     argument: value
@@ -32,99 +33,111 @@ general structure of a directive is as follows:
   directive_option: value
 ```
 
-The ```text_parser``` currently supports the following top-level directives:
+The `text_parser` currently supports the following top-level directives:
 
-* pattern_match
-* pattern_group
-* json_template
-* export_facts
+* `pattern_match`
+* `pattern_group`
+* `json_template`
+* `export_facts`
 
 In addition to the directives, the following common directive options are
-currently supported.
+currently supported:
 
-* name
-* block
-* loop
-* loop_control
-    * loop_var
-* when
-* register
-* export
-* export_as
+* `name`
+* `block`
+* `loop`
+* `loop_control`
+
+  * `loop_var`
+
+* `when`
+* `register`
+* `export`
+* `export_as`
 
 Any of the directive options are accepted but in some cases, the option may
-provide no operation.  For instance, when using the ```export_facts```
-directive, the options ```register```, ```export``` and ```export_as``` are all
+provide no operation.  For instance, when using the `export_facts`
+directive, the options `register`, `export` and `export_as` are all
 ignored.  The module should provide warnings when an option is ignored.
 
 The following sections provide more details about how to use the parser
 directives to parse text into JSON structure.
 
 ## Directive Options
+
 This section provides details on the various options that are available to be
 configured on any directive.
 
-### name
-All entries in the parser file many contain a ```name``` directive.  The
-```name``` directive can be used to provide an arbitrary description as to the
-purpose of the parser items.  The use of ```name``` is optional for all 
+### `name`
+
+All entries in the parser file many contain a `name` directive.  The
+`name` directive can be used to provide an arbitrary description as to the
+purpose of the parser items.  The use of `name` is optional for all
 directives.
 
+The default value for `name` is `null`.
 
-The default value for ```name``` is ```null```
+### `register`
 
-### register
-The ```register``` directive option can be used same as would be used in an
+The `register` directive option can be used same as would be used in an
 Ansible playbook.  It will register the results of the directive operation into
-the named variable such that it can be retrieved later.  
+the named variable such that it can be retrieved later.
 
 However, be sure to make note that registered variables are not available
-outside of the parser context.  Any values registered are only availalbe within
+outside of the parser context.  Any values registered are only available within
 the scope of the parser activities.  If you want to provide values back to the
 playbook, you will have to define the [export](#export) option.
 
+The default value for `register` is `null`.
 
-The default value for ```register``` is ```null```
+<a id="export"></a>
 
-### export
+### `export`
+
 This option will allow any value to be exported back the calling task as an
-Ansible fact.  The ```export``` option accepts a boolean value that defines if
+Ansible fact.  The `export` option accepts a boolean value that defines if
 the registered fact should be exported to the calling task in the playbook (or
-role) scope.  To export the value, simply set ```export``` to True.  
+role) scope.  To export the value, simply set `export` to True.
 
-Note this option requires the ```register``` value to be set in some cases and will
-produce a warning message if the ```register``` option is not provided.
+Note this option requires the `register` value to be set in some cases and will
+produce a warning message if the `register` option is not provided.
 
-The default value for ```export``` is ```False```
+The default value for `export` is ``False`.
 
-### export_as
+### `export_as`
+
 This option will allow value to be exported back in the calling task as an
-Ansible fact in mentioned format. The ```export_as``` option accepts ```dict```,
-```hash```, ```object```, ```list```, ```elements``` that defines the structure
-of the exported value.
+Ansible fact in mentioned format. The `export_as` option can be used to define the structure of the exported data, which accepts:
 
-Note this option requires the ```register``` value to be set and ```export``` to be
-set as ```true```.
+* `dict`
+* `hash`
+* `object`
+* `list`
+* `elements` that defines the structure
+
+**Note** this option requires the `register`` value to be set and `export: True`.
 
 ### loop
+
 Sometimes it is necessary to loop over a directive in order to process values.
-Using the ```loop``` option, the parser will iterate over the directive and
-provide each of the values provided by the loop content to the directive for
-processing.  
+Using the `loop` option, the parser will iterate over the directive and
+provide each of the values provided by the loop contents to the directive for
+processing.
 
 Access to the individual items is the same as it would be for Ansible
 playbooks.  When iterating over a list of items, you can access the individual
-item using the ```{{ item }}``` variable.  When looping over a hash, you can
-access ```{{ item.key }}``` and ```{{ item.value }}```.
+item using the `{{ item }}` variable.  When looping over a hash, you can
+access `{{ item.key }}` and `{{ item.value }}`.
 
-### loop_control
-```loop_control``` option can be used to specify the name of the variable to be
-used for the loop instead of default loop variable ```item```.
-When looping over a hash, you can access {{ foo.key }} and {{ foo.value }} where ```foo```
-is ```loop_var```.
-The general structure of ```loop_control``` is as follow:
+### `loop_control`
 
-```
+`loop_control` option can be used to specify the name of the variable to be
+used for the loop instead of default loop variable `item`.
+When looping over a hash, you can access `{{ foo.key }}` and `{{ foo.value }}` where ``foo`
+is `loop_var`.
+The general structure of `loop_control` is as follow:
+
+```yaml
 - name: User defined variable
   pattern_match:
     regex: "^(\\S+)"
@@ -135,16 +148,17 @@ The general structure of ```loop_control``` is as follow:
 
 ```
 
-### when
-The ```when``` option allows for a conditional to be placed on the directive to
-decided if it is executed or not.  The ```when``` option operates the same as
+### `when`
+
+The `when` option allows for a conditional to be placed on the directive to
+decided if it is executed or not.  The `when` option operates the same as
 it would in an Ansible playbook.
 
 For example, let's assume we only want to match perform the match statement
-when the value of ```ansible_network_os``` is set to ``ios```.  We would apply
-the ```when``` conditional as such:
+when the value of `ansible_network_os` is set to `ios`.  We would apply
+the `when` conditional as such:
 
-```
+```yaml
 - name: conditionally matched var
   pattern_match:
     regex: "hostname (.+)"
@@ -152,44 +166,51 @@ the ```when``` conditional as such:
 ```
 
 ## Directives
-The directives perform actions on the content using regular expressions to
-extract various values.  Each directive provides some additional arguments that
-can be used to perform its operation.  
 
-### pattern_match
-The ```pattern_match``` directive is used to extract one or more values from
+The directives perform actions on the contents using regular expressions to
+extract various values.  Each directive provides some additional arguments that
+can be used to perform its operation.
+
+### `pattern_match`
+
+The `pattern_match` directive is used to extract one or more values from
 the structured ASCII text based on regular expressions.
 
 The following arguments are supported for this directive:
 
-* regex
-* content
-* match_all
-* match_greedy
+* `regex`
+* `contents`
+* `match_all`
+* `match_greedy`
 
+### `pattern_group`
 
-### pattern_group
-The ```pattern_group``` directive can be used to group multiple
-```pattern_match``` results together.  
-
+The `pattern_group` directive can be used to group multiple
+`pattern_match` results together.
 
 The following arguments are supported for this directive:
 
-### json_template
-The ```json_template``` directive will create a JSON data structure based on a
+* `json_template`
+* `set_vars`
+* `export_facts`
+
+### `json_template`
+
+The `json_template` directive will create a JSON data structure based on a
 template.  This directive will allow you to template out a multi-level JSON
-blob.  
+blob.
 
 The following arguments are supported for this directive:
 
-* template
+* `template`
 
+### `set_vars`
 
-### set_vars
+TBD
 
+### `export_facts`
 
-### export_facts
-The ```export_facts``` directive takes an arbitrary set of key / value pairs
+The `export_facts` directive takes an arbitrary set of key / value pairs
 and exposes (returns) them back to the playbook global namespace.  Any key /
 value pairs that are provided in this directive become available on the host.
 

--- a/docs/directives/parser_directives.md
+++ b/docs/directives/parser_directives.md
@@ -179,7 +179,7 @@ the structured ASCII text based on regular expressions.
 The following arguments are supported for this directive:
 
 * `regex`
-* `contents`
+* `content`
 * `match_all`
 * `match_greedy`
 

--- a/docs/directives/template_directives.md
+++ b/docs/directives/template_directives.md
@@ -1,107 +1,114 @@
-CLI Template Directives
-=======================
-The ```network_template``` module supports a number of keyword based objectives that
+# CLI Template Directives
+
+The `network_template` module supports a number of keyword based objectives that
 handle how to process the template.  Templates are broken up into a series
 of blocks that process lines.  Blocks are logical groups that have a common
 set of properties in common.
 
 Blocks can also include other template files and are processed in the same
-manner as lines.  See includes below for a description on how to use the 
-the include directive.
+manner as lines.  See includes below for a description on how to use the
+include directive.
 
-The template module works by processing the lines directives in sequential 
+The template module works by processing the lines directives in sequential
 order.  The module will attempt to template each line in the lines directive
-and, if successful, add the line to the final output.  Values used for 
+and, if successful, add the line to the final output.  Values used for
 variable substitution come from the host facts.  If the line could not
-be successfully templated, the line is skipped and a warning message is 
-displayed that the line could not be templated.  
+be successfully templated, the line is skipped and a warning message is
+displayed that the line could not be templated.
 
 There are additional directives that can be combined to support looping over
 lists and hashes as well as applying conditional statements to blocks, lines
 and includes.
 
-# name
-Entries in the template may contain a ```name``` field.  The ```name``` field 
-is used to provide a description of the entry.  It is also used to provide 
-feedback when processing the template to indicate when an entry is 
+## `name`
+
+Entries in the template may contain a `name` field.  The `name` field
+is used to provide a description of the entry.  It is also used to provide
+feedback when processing the template to indicate when an entry is
 skipped or fails.
 
-# lines
-The ```lines``` directive provides an ordered list of statements to attempt
-to template.  Each entry in the ```lines``` directive will be evaluated for
-variable substitution.  If the entry can be successfully templated, then the 
+## `lines`
+
+The `lines` directive provides an ordered list of statements to attempt
+to template.  Each entry in the `lines` directive will be evaluated for
+variable substitution.  If the entry can be successfully templated, then the
 output will be added to the final set of entries.  If the entry cannot be
 successfully templated, then the entry is ignored (skipped) and a warning
-message is provided.  If the entry in the ```lines``` directive contains 
-only static text (no variables), then the line will always be processed.  
+message is provided.  If the entry in the `lines` directive contains
+only static text (no variables), then the line will always be processed.
 
-The ```lines``` directive also supports standard Jinja2 filters as well as any
+The `lines` directive also supports standard Jinja2 filters as well as any
 Ansible specific Jinja2 filters.  For example, lets assume we want to add a
 default value if a more specific value was not assigned by a fact.
 
-```
+```yaml
 - name: render the system hostname
   lines:
     - "hostname {{ hostname | default(inventory_hostname_short }}"
 ```
 
+## `block`
 
-# block
-A group of ```lines``` directives can be combined into a ```block``` 
-directive.  These ```block``` directives are used to apply a common set of 
-values to one or more ```lines``` or ```includes``` entries.  
+A group of `lines` directives can be combined into a `block`
+directive.  These `block` directives are used to apply a common set of
+values to one or more `lines` or `includes` entries.
 
-For instance, a ```block``` directive that contains one or more ```lines``` 
-entries could be use the same set of ```loop``` values or have a 
-common ```when``` conditional statement applied to them.
+For instance, a `block` directive that contains one or more `lines`
+entries could be use the same set of `loop` values or have a
+common `when` conditional statement applied to them.
 
-# include
+## `include`
+
 Sometimes it is advantageous to break up templates into separate files and
-combine them.  The ```include``` directive will instruct the current template
-to load another template file and process it.  
+combine them.  The `include` directive will instruct the current template
+to load another template file and process it.
 
-The ```include``` directive also supports variable substitution for the 
-provided file name and can be processed with the ```loop``` and ```when```
+The `include` directive also supports variable substitution for the
+provided file name and can be processed with the `loop` and ``when`
 directives.
 
-# when
-The ```when``` directive allows for conditional statements to be applied to 
-a set of ```lines```, a ```block``` and/or the ```include``` directive.  The
-```when``` statement is evaluated prior to processing the statements and if
+## `when`
+
+The `when` directive allows for conditional statements to be applied to
+a set of `lines`, a `block` and/or the `include` directive.  The
+`when` statement is evaluated prior to processing the statements and if
 the condition is true, the statements will attempt to be templated.  If the
 statement is false, the statements are skipped and a message returned.
 
-# loop
-Depending on the input facts, sometimes it is necessary to iterate over a 
-set of statements.  The ```loop``` directive allows the same set of statements
-to be processed in such a manner.  The ```loop``` directive takes, as input, 
+## `loop`
+
+Depending on the input facts, sometimes it is necessary to iterate over a
+set of statements.  The `loop` directive allows the same set of statements
+to be processed in such a manner.  The `loop` directive takes, as input,
 the name of a fact that is either a list or a hash and iterates over the
-statements for each entry.  
+statements for each entry.
 
-When the provided fact is a list of items, the value will be assigned to a 
-variable called ```item``` and can be referenced by the statements.
+When the provided fact is a list of items, the value will be assigned to a
+variable called `item` and can be referenced by the statements.
 
-When the provided fact is a hash of items, the hash key will be assigned to 
-the ```item.key``` variable and the hash value will be assigned to the 
-```item.value``` variable.  Both can then be referenced by the statements.
+When the provided fact is a hash of items, the hash key will be assigned to
+the `item.key` variable and the hash value will be assigned to the
+`item.value` variable.  Both can then be referenced by the statements.
 
-# loop_control
-The ```loop_control``` directive allows the template to configure aspects 
+## `loop_control`
+
+The `loop_control` directive allows the template to configure aspects
 related to how loops are process.  This directive provides a set of suboptions
 to configure how loops are processed.
 
-## loop_var
-The ```loop_var``` directive allows the template to override the default
-variable name ```item```.  This is useful when handling nested loops such
-that both inner and outer loops values can be accessed.  
+### `loop_var`
 
-When setting the ```loop_var``` to some string, the string will replace
-```item``` as the variable name used to access the values.
+The `loop_var` directive allows the template to override the default
+variable name `item`.  This is useful when handling nested loops such
+that both inner and outer loops values can be accessed.
+
+When setting the `loop_var` to some string, the string will replace
+`item` as the variable name used to access the values.
 
 For example, lets assume instead of using item, we want to use a different
 variable name such as entry:
 
-```
+```yaml
 - name: render entries
   lines:
     - "hostname {{ entry.hostname }}"
@@ -111,13 +118,14 @@ variable name such as entry:
     loop_var: entry
 ```
 
-# join
-When building template statements that include optional values for
-configuration, the ```join``` directive can be useful.  The ```join```
-directive instructs the template to combine the templated lines together
-into a single string to insert into the configuration. 
+## `join`
 
-For example, lets assume there is a need to add the following statement to 
+When building template statements that include optional values for
+configuration, the `join` directive can be useful.  The `join`
+directive instructs the template to combine the templated lines together
+into a single string to insert into the configuration.
+
+For example, lets assume there is a need to add the following statement to
 the configuration:
 
 ```
@@ -128,7 +136,7 @@ ip domain-name redhat.com
 To support templating the above lines, the facts might include the domain-name
 and the vrf name values.  Here is the example facts:
 
-```
+```yaml
 ---
 system:
   - domain_name: ansible.com
@@ -138,7 +146,7 @@ system:
 
 And the template statement would be the following:
 
-```
+```yaml
 - name: render domain-name
   lines:
     - "ip domain-name {{ item.domain_name }}"
@@ -147,16 +155,16 @@ And the template statement would be the following:
   join: yes
 ```
 
-When this entry is processed, the first iteration will successfully template 
-both lines and add ```ip domain-name ansible.com vrf management``` to the 
-output. 
+When this entry is processed, the first iteration will successfully template
+both lines and add `ip domain-name ansible.com vrf management` to the
+output.
 
-When the second entry is processed, the first line will be successfully 
+When the second entry is processed, the first line will be successfully
 templated but since there is no management key, the second line will return a
-null value.  The final line added to the configuration will be ``` ip
-domain-name redhat.com```.
+null value.  The final line added to the configuration will be ` ip
+domain-name redhat.com`.
 
-If the ```join``` directive had been omitted, then the final set of
+If the `join` directive had been omitted, then the final set of
 configuration statements would be as follows:
 
 ```
@@ -165,15 +173,16 @@ vrf management
 ip domain-name redhat.com
 ```
 
-# join_delimiter
-When the ```join``` delimiter is used, the templated values are combined into a
+## `join_delimiter`
+
+When the `join` delimiter is used, the templated values are combined into a
 single string that is added to the final output.  The lines are joined using a
-space.  The delimiting character used when processing the ```join``` can be
-modified using ```join_delimiter``` directive.
+space.  The delimiting character used when processing the `join` can be
+modified using `join_delimiter` directive.
 
 Here is an example of using the this directive.  Take the following entry:
 
-```
+```yaml
 - name: render domain-name
   lines:
     - "ip domain-name {{ item.domain_name }}"
@@ -191,14 +200,15 @@ ip domain-name ansible.com,vrf management
 ip domain-name redhat.com
 ```
 
-# indent
-The ```indent``` directive is used to add one or more leading spaces to the
+## `indent`
+
+The `indent` directive is used to add one or more leading spaces to the
 final templated statement.  It can be used to recreated a structured
-configuration file.  
+configuration file.
 
 Take the following template entry as an example:
 
-```
+```yaml
 - name: render the interface context
   lines: "interface Ethernet0/1"
 
@@ -224,37 +234,39 @@ interface Ethernet0/1
 !
 ```
 
-# required
-The ```required``` directive specifies that all of the statements must be
-templated otherwise a failure is generated.  Essentially it is a way to 
+## `required`
+
+The `required` directive specifies that all of the statements must be
+templated otherwise a failure is generated.  Essentially it is a way to
 make certain that the variables are defined.
 
 For example, take the following:
 
-```
+```yaml
 - name: render router ospf context
   lines:
     - "router ospf {{ process_id }}"
   required: yes
 ```
 
-When the above is processed, if the variable ```process_id``` is not present,
-then the statement cannot be templated.  Since the ```required``` directive
+When the above is processed, if the variable `process_id` is not present,
+then the statement cannot be templated.  Since the `required` directive
 is set to true, the statement will cause the template to generate a failure
 message.
 
-# missing_key
+## `missing_key`
+
 By default, when statements are processed and a variable is undefined, the
 module will simply display a warning message to the screen.  In some cases, it
 is desired to either suppress warning messages on a missing key or to force the
-module to fail on a missing key. 
+module to fail on a missing key.
 
-To change the default behaviour, use the ```missing_key``` directive.  This 
+To change the default behaviour, use the `missing_key` directive.  This
 directive accepts one of three choices:
 
-* ignore
-* warn (default)
-* fail
+* `ignore`
+* `warn` (default)
+* `fail`
 
 The value of this directive will instruct the template how to handle any
 condition where the desired variable is undefined.

--- a/docs/tests/test_guide.md
+++ b/docs/tests/test_guide.md
@@ -33,8 +33,6 @@ role_name
 
 If you add any new Role for test, make sure to include the role in `test.yml`:
 
-`test.yml`
-
 ```yaml
 
   roles:
@@ -43,15 +41,13 @@ If you add any new Role for test, make sure to include the role in `test.yml`:
     - $role_name
 ```
 
-## Add new platforms tests for existing roles
+## Add new platforms tests to an existing roles
 
 Create directory with the `platform_name` in `output` and `parsers` directories
 which will contain output and parser files of the platform.
 
 Add corresponding playbook with the `platform_name` in `tasks/$platform_name.yaml`
-and make an entry in `tasks/main.yaml`:
-
-`tasks/main.yaml`
+and add an entry in `tasks/main.yaml`:
 
 ```yaml
 - name: platform_name text_parser test

--- a/docs/tests/test_guide.md
+++ b/docs/tests/test_guide.md
@@ -1,18 +1,16 @@
-Test Guide
-==========
-The tests in network-engine are role based where the entrypoint is ```tests/test.yml```.
-The tests for textfsm and text_parser are run against localhost.
+# Test Guide
 
+The tests in network-engine are role based where the entry point is `tests/test.yml`.
+The tests for `textfsm` and `text_parser` are run against `localhost`.
 
-### How to run tests locally:
+## How to run tests locally
 
 ```
 cd tests/
 ansible-playbook -i inventory test.yml
 ```
 
-
-### Role Structure:
+## Role Structure
 
 ```
 role_name
@@ -33,10 +31,11 @@ role_name
         └── main.yaml
 ```
 
-If you add any new Role for test, make sure to include the role in ```test.yml```:
+If you add any new Role for test, make sure to include the role in `test.yml`:
 
-```
-# test.yml
+`test.yml`
+
+```yaml
 
   roles:
     - text_parser
@@ -44,17 +43,17 @@ If you add any new Role for test, make sure to include the role in ```test.yml``
     - $role_name
 ```
 
+## Add new platforms tests for existing roles
 
-### Add new platforms tests for existing roles:
-
-Create directory with the platform_name in ```output``` and ```parsers``` directories
+Create directory with the `platform_name` in `output` and `parsers` directories
 which will contain output and parser files of the platform.
 
-Add corresponding playbook with the platform_name in ```tasks/$platform_name.yaml```
-and make an entry in ```tasks/main.yaml```:
+Add corresponding playbook with the `platform_name` in `tasks/$platform_name.yaml`
+and make an entry in `tasks/main.yaml`:
 
-```
-# tasks/main.yaml
+`tasks/main.yaml`
+
+```yaml
 - name: platform_name text_parser test
   import_tasks: platform_name.yaml
 ```

--- a/lib/network_engine/plugins/__init__.py
+++ b/lib/network_engine/plugins/__init__.py
@@ -4,6 +4,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 from ansible.plugins.loader import PluginLoader
 
 template_loader = PluginLoader(

--- a/lib/network_engine/plugins/parser/pattern_match.py
+++ b/lib/network_engine/plugins/parser/pattern_match.py
@@ -4,6 +4,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import re
 
 from ansible.module_utils.six import iteritems

--- a/lib/network_engine/plugins/template/__init__.py
+++ b/lib/network_engine/plugins/template/__init__.py
@@ -4,6 +4,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import collections
 
 from ansible.module_utils.six import iteritems, string_types
@@ -59,7 +62,7 @@ class TemplateBase(object):
         return value
 
     def _update(self, d, u):
-        for k, v in u.iteritems():
+        for k, v in iteritems(u):
             if isinstance(v, collections.Mapping):
                 d[k] = self._update(d.get(k, {}), v)
             else:

--- a/lib/network_engine/plugins/template/json_template.py
+++ b/lib/network_engine/plugins/template/json_template.py
@@ -4,6 +4,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import collections
 
 from ansible.module_utils.six import string_types

--- a/lib/network_engine/plugins/template/normal.py
+++ b/lib/network_engine/plugins/template/normal.py
@@ -4,6 +4,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 from network_engine.plugins.template import TemplateBase
 
 

--- a/library/cli.py
+++ b/library/cli.py
@@ -66,7 +66,9 @@ RETURN = """
 stdout:
   description: returns the output from the command
   returned: always
+  type: dict
 json:
   description: the output converted from json to a hash
   returned: always
+  type: dict
 """


### PR DESCRIPTION
**Code Issues**

* Python 3: Ensure all plugins & modules have `__future__`
* Python 3: Correct use of `iteritems` fo
* Define `type` for `library/cli.py`

**Docs Issues**

* content (not contents)
* Correct typos/spelling issues
* Github -> GitHub
* Use GitHub Markdown (We may change to RST at a future points)
* Use syntax highlighting where it makes sense
* Correctly use code formatting
* Ensure code headings are formatted correctly, "foo_bar" isn't valid