### PR TITLE
Roles requires Ansible 2.5

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
 
   license: GPLv3
 
-  min_ansible_version: 1.2
+  min_ansible_version: 2.5
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:


### PR DESCRIPTION
This role requires Core functionality which only exists in Ansible 2.5.0
and later.