### PR TITLE
Initial release notes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,22 @@
+===============================
+Ansible Network: network-engine
+===============================
+
+2.5.0
+=====
+
+Major Changes
+-------------
+
+- Initial release of the ``network-engine`` Ansible role.
+
+- This role provides the foundation for building network roles by providing modules and plugins that are common to all Ansible Network roles. All of the artifacts in this role can be used independent of the platform that is being managed.
+
+
+New Modules
+-----------
+
+- NEW ``text_parser`` Parses ASCII text into JSON facts using text_parser engine. Provides a rules base text parser that is closely modeled after the Ansible playbook language. This parser will iterate of the rules and parse the output of structured ASCII text into a JSON data structure that can be added to the inventory host facts.
+
+- NEW ``textfsm`` Parses ASCII text into JSON facts using textfsm engine. Provides textfsm rule based templates to parse data from text. The template acting as parser will iterate of the rules and parse the output of structured ASCII text into a JSON data structure that can be added to the inventory host facts.
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Major Changes
 New Modules
 -----------
 
-- NEW ``text_parser`` Parses ASCII text into JSON facts using text_parser engine. Provides a rules base text parser that is closely modeled after the Ansible playbook language. This parser will iterate of the rules and parse the output of structured ASCII text into a JSON data structure that can be added to the inventory host facts.
+- NEW ``text_parser`` Parses ASCII text into JSON facts using text_parser engine. Provides a rules-based text parser that is closely modeled after the Ansible playbook language. This parser will iterate over the rules and parse the output of structured ASCII text into a JSON data structure that can be added to the inventory host facts.
 
-- NEW ``textfsm`` Parses ASCII text into JSON facts using textfsm engine. Provides textfsm rule based templates to parse data from text. The template acting as parser will iterate of the rules and parse the output of structured ASCII text into a JSON data structure that can be added to the inventory host facts.
+- NEW ``textfsm`` Parses ASCII text into JSON facts using textfsm engine. Provides textfsm rules-based templates to parse data from text. The template acting as parser will iterate of the rules and parse the output of structured ASCII text into a JSON data structure that can be added to the inventory host facts.
 

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,0 +1,20 @@
+---
+# FIXME GUNDALOW: This file will need work once we have defined the Git Tag & branch strategy
+#                 Currently we've just copied ansible/ansible's changelogs/config.yaml
+release_tag_re: '(v(?:[\d.ab\-]|rc)+)'
+pre_release_tag_re: '(?P<pre_release>(?:[ab]|rc)+\d*)$'
+notesdir: fragments
+prelude_section_name: release_summary
+sections:
+- ['major_changes', 'Major Changes']
+- ['minor_changes', 'Minor Changes']
+- ['deprecated_features', 'Deprecated Features']
+- ['removed_features', 'Removed Features (previously deprecated)']
+- ['new_lookup_plugins', 'New Lookup Plugins']
+- ['new_callback_plugins', 'New Callback Plugins']
+- ['new_connection_plugins', 'New Connection Plugins']
+- ['new_test_plugins', 'New Test Plugins']
+- ['new_filter_plugins', 'New Filter Plugins']
+- ['new_modules', 'New Modules']
+- ['bugfixes', 'Bugfixes']
+- ['known_issues', 'Known Issues']

--- a/changelogs/fragments/v0-initial-release.yaml
+++ b/changelogs/fragments/v0-initial-release.yaml
@@ -5,7 +5,7 @@ major_changes:
 new_modules:
 - NEW ``text_parser`` Parses ASCII text into JSON facts using text_parser engine.
   Provides a rules base text parser that is closely modeled after the Ansible
-  playbook language.  This parser will iterate of the rules and parse the
+  playbook language. This parser will iterate of the rules and parse the
   output of structured ASCII text into a JSON data structure that can be
   added to the inventory host facts.
 - NEW ``textfsm`` Parses ASCII text into JSON facts using textfsm engine.

--- a/changelogs/fragments/v0-initial-release.yaml
+++ b/changelogs/fragments/v0-initial-release.yaml
@@ -10,4 +10,3 @@ new_modules:
   added to the inventory host facts.
 - NEW ``textfsm`` Parses ASCII text into JSON facts using textfsm engine.
   Provides textfsm rules-based templates to parse data from text. The template acting as parser will iterate of the rules and parse the output of structured ASCII text into a JSON data structure that can be added to the inventory host facts.
-

--- a/changelogs/fragments/v0-initial-release.yaml
+++ b/changelogs/fragments/v0-initial-release.yaml
@@ -1,0 +1,7 @@
+major_changes:
+ - Initial release of ``network-engine``
+ - This role provides the foundation for building network roles by providing
+   modules and plugins that are common to all Ansible Network roles.  All of
+   the artifacts in this role can be used independent of the platform that is
+   being managed.
+

--- a/changelogs/fragments/v0-initial-release.yaml
+++ b/changelogs/fragments/v0-initial-release.yaml
@@ -1,7 +1,13 @@
 major_changes:
- - Initial release of ``network-engine``
- - This role provides the foundation for building network roles by providing
-   modules and plugins that are common to all Ansible Network roles.  All of
-   the artifacts in this role can be used independent of the platform that is
-   being managed.
+- Initial release of the ``network-engine`` Ansible role.
+- This role provides the foundation for building network roles by providing modules and plugins that are common to all Ansible Network roles. All of the artifacts in this role can be used independent of the platform that is being managed.
+
+new_modules:
+- NEW ``text_parser`` Parses ASCII text into JSON facts using text_parser engine.
+  Provides a rules base text parser that is closely modeled after the Ansible
+  playbook language.  This parser will iterate of the rules and parse the
+  output of structured ASCII text into a JSON data structure that can be
+  added to the inventory host facts.
+- NEW ``textfsm`` Parses ASCII text into JSON facts using textfsm engine.
+  Provides textfsm rule based templates to parse data from text. The template acting as parser will iterate of the rules and parse the output of structured ASCII text into a JSON data structure that can be added to the inventory host facts.
 

--- a/changelogs/fragments/v0-initial-release.yaml
+++ b/changelogs/fragments/v0-initial-release.yaml
@@ -4,10 +4,10 @@ major_changes:
 
 new_modules:
 - NEW ``text_parser`` Parses ASCII text into JSON facts using text_parser engine.
-  Provides a rules base text parser that is closely modeled after the Ansible
-  playbook language. This parser will iterate of the rules and parse the
+  Provides a rules-based text parser that is closely modeled after the Ansible
+  playbook language. This parser will iterate over the rules and parse the
   output of structured ASCII text into a JSON data structure that can be
   added to the inventory host facts.
 - NEW ``textfsm`` Parses ASCII text into JSON facts using textfsm engine.
-  Provides textfsm rule based templates to parse data from text. The template acting as parser will iterate of the rules and parse the output of structured ASCII text into a JSON data structure that can be added to the inventory host facts.
+  Provides textfsm rules-based templates to parse data from text. The template acting as parser will iterate of the rules and parse the output of structured ASCII text into a JSON data structure that can be added to the inventory host facts.
 


### PR DESCRIPTION
Add release fragment (and rendered RST version) for network-engine 2.5.0

In the future this maybe end up as rendered HTML, though for the moment
we add in the RST that reno produces into the repo

`changelog/config.yml` has been taken from `ansible/ansible` this will need work in the future