### PR TITLE
Add new lookup plugin json_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ The following is a list of modules that are provided by this role.
 
 The following is a list of plugins that are provided by this role.
 
-None
+### Lookup
+
+* `json_template` [[source]](lookup_plugins/json_template.py)
 
 ## Dependencies
 

--- a/lookup_plugins/json_template.py
+++ b/lookup_plugins/json_template.py
@@ -1,0 +1,64 @@
+# (c) 2018 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+lookup: json_template
+author: Ansible Network
+version_added: "2.5"
+short_description: retrieve and template device configuration
+description:
+  - This lookup plugin returns the content of a JSON file in JSON format.
+    configuration.
+options:
+  _terms:
+    description: list of files for lookup
+"""
+
+EXAMPLES = """
+- name: show interface lookup result
+  debug: msg="{{ lookup('json_template', './show_interface.json') }}
+"""
+
+RETURN = """
+_raw:
+   description: JSON file(s) content
+"""
+
+import json
+
+from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.plugins.lookup import LookupBase, display
+from ansible.module_utils._text import to_bytes
+from ansible.module_utils.network.common.utils import to_list
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.path.pardir, 'lib'))
+from network_engine.plugins import template_loader
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables, **kwargs):
+
+        self.ds = variables.copy()
+        ret = list()
+
+        display.debug("File lookup term: %s" % terms[0])
+
+        lookupfile = self.find_file_in_search_path(variables, 'files', terms[0])
+        display.vvvv("File lookup using %s as file" % lookupfile)
+        try:
+            if lookupfile:
+                with open(to_bytes(lookupfile, errors='surrogate_or_strict'), 'rb') as f:
+                    json_data = to_text(f.read(), errors='surrogate_or_strict')
+                    ret.append(json.load(f))
+            else:
+                raise AnsibleParserError()
+        except AnsibleParserError:
+            raise AnsibleError("could not locate file in lookup: %s" % terms[0])
+
+        return ret

--- a/tests/json_template/defaults/main.yaml
+++ b/tests/json_template/defaults/main.yaml
@@ -1,0 +1,1 @@
+template_path: "{{ role_path }}/templates"

--- a/tests/json_template/meta/main.yaml
+++ b/tests/json_template/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - ../../../network-engine

--- a/tests/json_template/tasks/json_lookup.yaml
+++ b/tests/json_template/tasks/json_lookup.yaml
@@ -1,0 +1,13 @@
+- name: generate config
+  debug:
+    msg: "{{ lookup('json_template', '{{ template_path }}/config.json') }}"
+  register: result
+
+- assert:
+    that:
+      - "'GigabitEthernet0/0' in result.msg"
+      - "'config' in result['msg']['GigabitEthernet0/0']"
+      - "'Configured by Ansible' in result['msg']['GigabitEthernet0/0']['config']['description']"
+      - "result['msg']['GigabitEthernet0/0']['config']['mtu'] == 1500"
+      - "'iGbE' in result['msg']['GigabitEthernet0/0']['config']['type']"
+      - "'GigabitEthernet0/0' in result['msg']['GigabitEthernet0/0']['config']['name']"

--- a/tests/json_template/tasks/main.yaml
+++ b/tests/json_template/tasks/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: json_template lookup plugin test
+  import_tasks: json_lookup.yaml

--- a/tests/json_template/templates/config.json
+++ b/tests/json_template/templates/config.json
@@ -1,0 +1,26 @@
+{
+    "object": [
+	{
+	    "object": [
+		{
+		    "value": "GigabitEthernet0/0",
+		    "key": "name"
+		},
+		{
+		    "value": "iGbE",
+		    "key": "type"
+		}, 
+		{
+		    "value": "1500",
+		    "key": "mtu"
+		}, 
+		{
+		    "value": "Configured by Ansible",
+		    "key": "description"
+		}
+	    ],
+	    "key": "config"
+        }
+    ],
+    "key": "GigabitEthernet0/0"
+}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,3 +4,4 @@
   roles:
     - { role: 'text_parser', tags: 'text_parser' }
     - { role: 'textfsm', tags: 'textfsm' }
+    - { role: 'json_template', tags: 'json_template' }


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>
Fixes https://github.com/ansible-network/network-engine/issues/32
Tests
Playbook:
```
- name: generate config in JSON
  debug: msg="{{ lookup('json_template', 'config.json') }}"
```

JSON file:
```
{
    "object": [
	{
	    "object": [
		{
		    "value": "GigabitEthernet0/0",
		    "key": "name"
		},
		{
		    "value": "iGbE",
		    "key": "type"
		}, 
		{
		    "value": "1500",
		    "key": "mtu"
		}, 
		{
		    "value": "Configured by Ansible",
		    "key": "description"
		}
	    ],
	    "key": "config"
        }
    ],
    "key": "GigabitEthernet0/0"
}
````

Return
```
ok: [localhost] => {
    "msg": {
        "GigabitEthernet0/0": {
            "config": {
                "description": "Configured by Ansible", 
                "mtu": 1500, 
                "name": "GigabitEthernet0/0", 
                "type": "iGbE"
            }
        }
    }
}
```
