### PR TITLE
Link to docs & Ansible 2.5 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,17 @@ Any open bugs and/or feature requests are tracked in [GitHub issues](../../issue
 
 Interested in contributing to this role, please see [CONTRIBUTING](CONTRIBUTING.md)
 
+## Documentation
+
+* User guide: [[Parser Directives]](docs/directives/parser_directives.md)
+* User guide: [[Template Directives]](docs/directives/template_directives.md)
+* Development guide: [[How to test]](docs/tests/test_guide.md)
+
+For module documentation see the [modules](#modules) section.
+
 ## Requirements
 
-None
+* Ansible 2.5.0 (or higher)
 
 ## Tasks
 
@@ -30,7 +38,7 @@ None
 
 The following is a list of modules that are provided by this role.
 
-* `cli` [[source]](library/cli.py)
+* `cli` [[source]](action_plugin/cli.py)
 * `get_config` [[source]](library/get_config.py)
 * `text_parser` [[source]](library/text_parser.py)
 * `textfsm` [[source]](library/textfsm.py)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Interested in contributing to this role, please see [CONTRIBUTING](CONTRIBUTING.
 ## Documentation
 
 * User guide: [[Parser Directives]](docs/directives/parser_directives.md)
-* User guide: [[Template Directives]](docs/directives/template_directives.md)
 * Development guide: [[How to test]](docs/tests/test_guide.md)
 
 For module documentation see the [modules](#modules) section.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ None
 The following is a list of modules that are provided by this role.
 
 * `cli` [[source]](action_plugin/cli.py)
-* `get_config` [[source]](library/get_config.py)
 * `text_parser` [[source]](library/text_parser.py)
 * `textfsm` [[source]](library/textfsm.py)
 


### PR DESCRIPTION
* Link to the various user & development guides
* Specifies that Ansible 2.5.0 is the required version
* Correct link to action_plugin docs as they have moved