### PR TITLE
Fix StringIO to work with Python3 in addition to Python2

### DIFF
--- a/action_plugins/textfsm.py
+++ b/action_plugins/textfsm.py
@@ -9,7 +9,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import StringIO
+from io import StringIO
 
 from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError
@@ -50,7 +50,7 @@ class ActionModule(ActionBase):
             if filename:
                 tmpl = open(filename)
             else:
-                tmpl = StringIO.StringIO()
+                tmpl = StringIO()
                 tmpl.write(src.strip())
                 tmpl.seek(0)
 

--- a/action_plugins/textfsm.py
+++ b/action_plugins/textfsm.py
@@ -9,7 +9,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from io import StringIO
+from ansible.module_utils.six import StringIO
 
 from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError


### PR DESCRIPTION
Currently import of StringIO raises an exception when using Python3.6. This should fix the bug, and is the general practice with modules in ansible-core.