### PR TITLE
adds conditional support to nested template objects

### DIFF
--- a/lib/network_engine/plugins/template/__init__.py
+++ b/lib/network_engine/plugins/template/__init__.py
@@ -68,3 +68,7 @@ class TemplateBase(object):
             else:
                 d[k] = v
         return d
+
+    def _check_conditional(self, when, variables):
+        conditional = "{%% if %s %%}True{%% else %%}False{%% endif %%}"
+        return self.template(conditional % when, variables)

--- a/lib/network_engine/plugins/template/json_template.py
+++ b/lib/network_engine/plugins/template/json_template.py
@@ -24,10 +24,10 @@ class TemplateEngine(TemplateBase):
             key = self.template(item['key'], variables)
 
             # FIXME moving to the plugin system breaks this
-            # when = item.get('when')
-            # if when is not None:
-            #     if not self._check_conditional(when, variables):
-            #         continue
+            when = item.get('when')
+            if when is not None:
+                if not self._check_conditional(when, variables):
+                    continue
 
             if 'value' in item:
                 value = item.get('value')


### PR DESCRIPTION
This change allows conditionals to be applied to sub keys when
templating json data structures. The conditional can be applied using
the `when:` directive