### PR TITLE
AnsibleFilterError, deprecations, and unused imports

### DIFF
--- a/action_plugins/text_parser.py
+++ b/action_plugins/text_parser.py
@@ -23,7 +23,7 @@ class ActionModule(ActionBase):
                            version='2.6',
                            removed=False)
 
-        del tmp # tmp no longer has any effect
+        del tmp  # tmp no longer has any effect
 
         if task_vars is None:
             task_vars = dict()

--- a/filter_plugins/network_engine.py
+++ b/filter_plugins/network_engine.py
@@ -14,7 +14,7 @@ from ansible.errors import AnsibleFilterError
 def interface_split(interface, key=None):
     match = re.match(r'([A-Za-z\-]*)(.+)', interface)
     if not match:
-        raise FilterError('unable to parse interface %s' % interface)
+        raise AnsibleFilterError('unable to parse interface %s' % interface)
     obj = {'name': match.group(1), 'index': match.group(2)}
     if key:
         return obj[key]
@@ -33,7 +33,7 @@ def interface_range(interface):
     else:
         match = re.match(r'([A-Za-z]*)(.+)', interface)
         if not match:
-            raise FilterError('unable to parse interface %s' % interface)
+            raise AnsibleFilterError('unable to parse interface %s' % interface)
         prefix = match.group(1)
         index = match.group(2)
 

--- a/library/_text_parser.py
+++ b/library/_text_parser.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'network'}
 
 

--- a/library/_textfsm.py
+++ b/library/_textfsm.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'network'}
 
 DOCUMENTATION = '''

--- a/lookup_plugins/json_template.py
+++ b/lookup_plugins/json_template.py
@@ -40,6 +40,7 @@ from ansible.module_utils._text import to_bytes, to_text
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.path.pardir, 'lib'))
 from network_engine.plugins import template_loader
 
+
 class LookupModule(LookupBase):
 
     def run(self, terms, variables, **kwargs):

--- a/lookup_plugins/json_template.py
+++ b/lookup_plugins/json_template.py
@@ -35,7 +35,7 @@ import sys
 
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.plugins.lookup import LookupBase, display
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils._text import to_bytes
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.path.pardir, 'lib'))
 from network_engine.plugins import template_loader

--- a/lookup_plugins/network_template.py
+++ b/lookup_plugins/network_template.py
@@ -72,7 +72,7 @@ class LookupModule(LookupBase):
 
                         when = task.pop('when', None)
                         if when is not None:
-                            if not self._check_conditional(when, task_vars):
+                            if not self._check_conditional(when, self.ds):
                                 display.vvv('skipping task due to conditional check failure')
                                 continue
 

--- a/lookup_plugins/network_template.py
+++ b/lookup_plugins/network_template.py
@@ -248,7 +248,6 @@ class LookupModule(LookupBase):
                 resp = self._coerce_to_native(resp)
             except AnsibleUndefinedVariable:
                 resp = None
-                pass
             finally:
                 self._templar.set_available_variables(tmp_avail_vars)
             return resp
@@ -260,7 +259,6 @@ class LookupModule(LookupBase):
             except Exception as exc:
                 if value is None or len(value) == 0:
                     return None
-                pass
         return value
 
     def _check_conditional(self, when, variables):

--- a/lookup_plugins/network_template.py
+++ b/lookup_plugins/network_template.py
@@ -33,14 +33,10 @@ _raw:
 """
 
 
-import os
-import re
 import collections
 
-from ansible import constants as C
 from ansible.plugins.lookup import LookupBase, display
 from ansible.module_utils.network.common.utils import to_list
-from ansible.module_utils.network.common.config import NetworkConfig
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_text, to_bytes
 from ansible.errors import AnsibleError, AnsibleUndefinedVariable


### PR DESCRIPTION
* Correct link of AnsibleFilterError
* Deprecated modules should be marked as such in `ANSIBLE_METADATA`
* Minor formatting fixes
* Remove unused imports