### PR TITLE
Enable Zuul

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,4 +1,13 @@
 - project:
     check:
       jobs:
-        - noop
+        - ansible-test-sanity
+        - ansible-role-tests-stable-py2
+        - ansible-role-tests-stable-py3
+        - ansible-role-tests-devel-py2
+    gate:
+      jobs:
+        - ansible-test-sanity
+        - ansible-role-tests-stable-py2
+        - ansible-role-tests-stable-py3
+        - ansible-role-tests-devel-py2

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+host_key_checking = False


### PR DESCRIPTION
Now we are happy with how network-engine-zuul has been performing, we
can make Zuul live on the main development repo