### PR TITLE
Run against ansible-role-tests-2.6-py3

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -4,10 +4,12 @@
         - ansible-test-sanity
         - ansible-role-tests-stable-py2
         - ansible-role-tests-stable-py3
+        - ansible-role-tests-2.6-py3
         - ansible-role-tests-devel-py2
     gate:
       jobs:
         - ansible-test-sanity
         - ansible-role-tests-stable-py2
         - ansible-role-tests-stable-py3
+        - ansible-role-tests-2.6-py3
         - ansible-role-tests-devel-py2


### PR DESCRIPTION
Until 2.6 is releases latest = 2.5.
To ensure we test all active branches since 2.5, run more tests.
Also split the py2/3 testing across devel & 2.6

Builds on https://github.com/ansible-network/ansible-zuul-jobs/pull/20