### PR TITLE
Templating the regex sent to the parser to allow us to use ansible va…

### DIFF
--- a/action_plugins/command_parser.py
+++ b/action_plugins/command_parser.py
@@ -358,6 +358,7 @@ class ActionModule(ActionBase):
 
     def do_pattern_match(self, regex, content=None, match_all=None, match_until=None, match_greedy=None):
         content = self.template(content, self.ds) or self.template("{{ content }}", self.ds)
+        regex = self.template(regex, self.ds)
         parser = parser_loader.get('pattern_match', content)
         return parser.match(regex, match_all, match_until, match_greedy)
 

--- a/docs/directives/parser_directives.md
+++ b/docs/directives/parser_directives.md
@@ -198,6 +198,14 @@ The following arguments are supported for this directive:
 * `match_all`
 * `match_greedy`
 
+The `regex` argument templates the value given to it so variables and filters can be used.
+Example :
+```yaml
+- name: Use a variable and a filter
+  pattern_match:
+    regex: "{{ inventory_hostname | lower }} (.+)"
+```
+
 ### `pattern_group`
 
 Use the `pattern_group` directive to group multiple


### PR DESCRIPTION
…rs in the regex string

This allows use of vars and filters inside the regex string.

Example. Looking for an interface name inside a different output where that interface name changes because this `pattern_match` is ran inside a loop. : 
```yaml
- name: match name for old ios versions
  pattern_match:
    regex: "^({{ (item | regex_search('System Name(?: -|:) (\\S+)', '\\1') | first).split('.')[0] }}.+$)"
    content: "{{ detail }}"
```