### PR TITLE
fixes an issue with using the extend directive with a loop

### DIFF
--- a/action_plugins/command_parser.py
+++ b/action_plugins/command_parser.py
@@ -245,6 +245,9 @@ class ActionModule(ActionBase):
         working_set = update_set
 
         if expand is True:
+            for key in path.split('.'):
+                working_set[key] = dict()
+                working_set = working_set[key]
             working_set[child] = {}
             for item in value:
                 working_set[child] = self.rec_update(working_set[child], item)


### PR DESCRIPTION
This change addresses a problem that would effectively cause the
directive to ignore the extend keyword when the export value is a
looped.  In that case, the return fact would be registered to the top
level key not the extended one.  This change addresses that issue such
that extend is honored during fact expansion