### PR TITLE
branch devel: Test against devel & 2.6 only

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -2,14 +2,12 @@
     check:
       jobs:
         - ansible-test-sanity
-        - ansible-role-tests-stable-py2
-        - ansible-role-tests-stable-py3
-        - ansible-role-tests-2.6-py3
         - ansible-role-tests-devel-py2
+        - ansible-role-tests-2.6-py2
+        - ansible-role-tests-2.6-py3
     gate:
       jobs:
         - ansible-test-sanity
-        - ansible-role-tests-stable-py2
-        - ansible-role-tests-stable-py3
-        - ansible-role-tests-2.6-py3
         - ansible-role-tests-devel-py2
+        - ansible-role-tests-2.6-py2
+        - ansible-role-tests-2.6-py3


### PR DESCRIPTION
The `devel` branch of network engine is for use with Ansible 2.6, so test against devel & 2.6