### PR TITLE
branch stable-2.5: Test against Ansible 2.5 only

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -2,14 +2,10 @@
     check:
       jobs:
         - ansible-test-sanity
-        - ansible-role-tests-stable-py2
-        - ansible-role-tests-stable-py3
-        - ansible-role-tests-2.6-py3
-        - ansible-role-tests-devel-py2
+        - ansible-role-tests-2.5-py2
+        - ansible-role-tests-2.5-py3
     gate:
       jobs:
         - ansible-test-sanity
-        - ansible-role-tests-stable-py2
-        - ansible-role-tests-stable-py3
-        - ansible-role-tests-2.6-py3
-        - ansible-role-tests-devel-py2
+        - ansible-role-tests-2.5-py2
+        - ansible-role-tests-2.5-py3


### PR DESCRIPTION
network-engine 2.5 is only supported for use with Ansible 2.5, so only
run the integration tests against that version.