### PR TITLE
fixes bug when loading a dir of parsers

### DIFF
--- a/action_plugins/command_parser.py
+++ b/action_plugins/command_parser.py
@@ -212,6 +212,8 @@ class ActionModule(ActionBase):
                                     for k, v in iteritems(r):
                                         facts.update({to_text(k): v})
 
+                task_vars.update(facts)
+
         result.update({
             'ansible_facts': facts,
             'included': sources


### PR DESCRIPTION
This change addresses a bug that when calling a dir with parsers, only
the last loaded parser is returned.