### PR TITLE
Doc match until

### DIFF
--- a/docs/directives/parser_directives.md
+++ b/docs/directives/parser_directives.md
@@ -210,7 +210,7 @@ The following arguments are supported for this directive:
 * `content`
 * `match_all`
 * `match_greedy`
-* `match_until`
+* `match_until` : Sets a ending boundary for `match_greedy`.
 
 The `regex` argument templates the value given to it so variables and filters can be used.
 Example :

--- a/docs/directives/parser_directives.md
+++ b/docs/directives/parser_directives.md
@@ -210,6 +210,7 @@ The following arguments are supported for this directive:
 * `content`
 * `match_all`
 * `match_greedy`
+* `match_until`
 
 The `regex` argument templates the value given to it so variables and filters can be used.
 Example :


### PR DESCRIPTION
The argument to end a block of text when searching with `match_greedy` was missing from the docs.