### PR TITLE
adds new lookup plugin config_template

### DIFF
--- a/lookup_plugins/config_template.py
+++ b/lookup_plugins/config_template.py
@@ -1,0 +1,48 @@
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2012-17 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+lookup: config_template
+author: Peter Sprygada (private)
+version_added: "2.7"
+short_description: retrieve contents of file after templating with Jinja2
+description:
+  - This lookup plugin implements the standard template plugin with a slight
+    twist in that it supports using default(omit) to remove an entire line
+options:
+  _terms:
+    description: list of files to template
+"""
+
+EXAMPLES = """
+- name: show templating results
+  debug: msg="{{ lookup('config_template', './some_template.j2') }}
+"""
+
+RETURN = """
+_raw:
+   description: file(s) content after templating
+"""
+from ansible.plugins.lookup.template import LookupModule as LookupBase
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables, **kwargs):
+
+        ret = super(LookupModule, self).run(terms, variables, **kwargs)
+
+        omit = variables['omit']
+        filtered = list()
+
+        for line in ret[0].split('\n'):
+            if all((line, omit not in line, not line.startswith('!'))):
+                filtered.append(line)
+
+        return [filtered]

--- a/tests/config_template/config_template/meta/main.yaml
+++ b/tests/config_template/config_template/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - ../../../ansible-network.network-engine

--- a/tests/config_template/config_template/tasks/main.yml
+++ b/tests/config_template/config_template/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- set_fact:
+    test: string
+
+- set_fact:
+    test_pass: "{{ lookup('config_template', 'pass.j2') }}"
+    test_fail: "{{ lookup('config_template', 'fail.j2') }}"
+
+- assert:
+    that:
+      - "'test string' in test_pass"
+      - "'test string' not in test_fail"
+

--- a/tests/config_template/config_template/templates/fail.j2
+++ b/tests/config_template/config_template/templates/fail.j2
@@ -1,0 +1,1 @@
+test {{ bad | default(omit) }}

--- a/tests/config_template/config_template/templates/pass.j2
+++ b/tests/config_template/config_template/templates/pass.j2
@@ -1,0 +1,1 @@
+test {{ test }}

--- a/tests/config_template/test.yml
+++ b/tests/config_template/test.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  connection: local
+  roles:
+    - config_template

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -11,3 +11,4 @@
 - import_playbook: netcfg_diff/test.yml
 - import_playbook: interface_range/test.yml
 - import_playbook: interface_split/test.yml
+- import_playbook: config_template/test.yml


### PR DESCRIPTION
This change adds a new lookup plugin that is designed to simply writing
templates for line based files such as network configurations.  It adds
the capabilite to pass default(omit) on a line and if the requested
variable is not defined, the entire line (including the static text) is
removed.