### PR TITLE
fix test dependency

### DIFF
--- a/tests/command_parser/command_parser/meta/main.yaml
+++ b/tests/command_parser/command_parser/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - ../../../network-engine

--- a/tests/command_parser/command_parser/tasks/main.yaml
+++ b/tests/command_parser/command_parser/tasks/main.yaml
@@ -1,3 +1,7 @@
 ---
+- name: import dependency role for test
+  import_role:
+    name: "{{ role_path.split('/tests/command_parser/command_parser')[0] }}"
+
 - name: ios command_parser test
   import_tasks: ios.yaml

--- a/tests/interface_range/interface_range/meta/main.yaml
+++ b/tests/interface_range/interface_range/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - ../../../network-engine

--- a/tests/interface_range/interface_range/tasks/main.yaml
+++ b/tests/interface_range/interface_range/tasks/main.yaml
@@ -1,3 +1,7 @@
 ---
+- name: import dependency role for test
+  import_role:
+    name: "{{ role_path.split('/tests/interface_range/interface_range')[0] }}"
+
 - name: interface_range test
   import_tasks: interface_range.yaml

--- a/tests/interface_split/interface_split/meta/main.yaml
+++ b/tests/interface_split/interface_split/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - ../../../network-engine

--- a/tests/interface_split/interface_split/tasks/main.yaml
+++ b/tests/interface_split/interface_split/tasks/main.yaml
@@ -1,3 +1,7 @@
 ---
+- name: import dependency role for test
+  import_role:
+    name: "{{ role_path.split('/tests/interface_split/interface_split')[0] }}"
+
 - name: interface_split test
   import_tasks: interface_split.yaml

--- a/tests/json_template/json_template/meta/main.yaml
+++ b/tests/json_template/json_template/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - ../../../network-engine

--- a/tests/json_template/json_template/tasks/main.yaml
+++ b/tests/json_template/json_template/tasks/main.yaml
@@ -1,3 +1,7 @@
 ---
+- name: import dependency role for test
+  import_role:
+    name: "{{ role_path.split('/tests/json_template/json_template')[0] }}"
+
 - name: json_template lookup plugin test
   import_tasks: json_lookup.yaml

--- a/tests/netcfg_diff/netcfg_diff/meta/main.yaml
+++ b/tests/netcfg_diff/netcfg_diff/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - ../../../network-engine

--- a/tests/netcfg_diff/netcfg_diff/tasks/main.yaml
+++ b/tests/netcfg_diff/netcfg_diff/tasks/main.yaml
@@ -1,3 +1,7 @@
 ---
+- name: import dependency role for test
+  import_role:
+    name: "{{ role_path.split('/tests/netcfg_diff/netcfg_diff')[0] }}"
+
 - name: ios config diff
   import_tasks: ios.yaml

--- a/tests/text_parser/text_parser/meta/main.yaml
+++ b/tests/text_parser/text_parser/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - ../../../network-engine

--- a/tests/text_parser/text_parser/tasks/main.yaml
+++ b/tests/text_parser/text_parser/tasks/main.yaml
@@ -1,3 +1,7 @@
 ---
+- name: import dependency role for test
+  import_role:
+    name: "{{ role_path.split('/tests/text_parser/text_parser')[0] }}"
+
 - name: ios text_parser test
   import_tasks: ios.yaml

--- a/tests/textfsm/textfsm/meta/main.yaml
+++ b/tests/textfsm/textfsm/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - ../../../network-engine

--- a/tests/textfsm/textfsm/tasks/main.yaml
+++ b/tests/textfsm/textfsm/tasks/main.yaml
@@ -1,3 +1,7 @@
 ---
+- name: import dependency role for test
+  import_role:
+    name: "{{ role_path.split('/tests/textfsm/textfsm')[0] }}"
+
 - name: ios textfsm test
   import_tasks: ios.yaml

--- a/tests/textfsm_parser/textfsm_parser/meta/main.yaml
+++ b/tests/textfsm_parser/textfsm_parser/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - ../../../network-engine

--- a/tests/textfsm_parser/textfsm_parser/tasks/main.yaml
+++ b/tests/textfsm_parser/textfsm_parser/tasks/main.yaml
@@ -1,3 +1,7 @@
 ---
+- name: import dependency role for test
+  import_role:
+    name: "{{ role_path.split('/tests/textfsm_parser/textfsm_parser')[0] }}"
+
 - name: ios textfsm_parser test
   import_tasks: ios.yaml

--- a/tests/vlan_compress/vlan_compress/meta/main.yaml
+++ b/tests/vlan_compress/vlan_compress/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - ../../../network-engine

--- a/tests/vlan_compress/vlan_compress/tasks/main.yaml
+++ b/tests/vlan_compress/vlan_compress/tasks/main.yaml
@@ -1,3 +1,7 @@
 ---
+- name: import dependency role for test
+  import_role:
+    name: "{{ role_path.split('/tests/vlan_compress/vlan_compress')[0] }}"
+
 - name: vlan_compress test
   import_tasks: vlan_compress.yaml

--- a/tests/vlan_expand/vlan_expand/meta/main.yaml
+++ b/tests/vlan_expand/vlan_expand/meta/main.yaml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - ../../../network-engine

--- a/tests/vlan_expand/vlan_expand/tasks/main.yaml
+++ b/tests/vlan_expand/vlan_expand/tasks/main.yaml
@@ -1,3 +1,7 @@
 ---
+- name: import dependency role for test
+  import_role:
+    name: "{{ role_path.split('/tests/vlan_expand/vlan_expand')[0] }}"
+
 - name: vlan_expand test
   import_tasks: vlan_expand.yaml


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>
**Summary:**
Don't hard code dependency for tests.
This commit will point to `network-engine` when cloned from github or installed via tar and `ansible-network.network-engine` when installed via galaxy.