### PR TITLE
task as function in main.yaml

### DIFF
--- a/docs/tasks/cli.md
+++ b/docs/tasks/cli.md
@@ -52,13 +52,9 @@ The following example runs CLI command on the network node.
 - hosts: ios01
   connection: network_cli
 
-  tasks:
-  - name: run cli command with cli task
-    import_role:
-      name: ansible-network.network-engine
-      tasks_from: cli
-    vars:
-      ansible_network_os: ios
+  roles:
+    - name: ansible-network.network-engine
+      function: cli
       command: show version
 
 ```
@@ -82,13 +78,10 @@ The following example runs cli command and parse output to JSON facts.
 - hosts: ios01
   connection: network_cli
 
-  tasks:
-  - name: run cli command and parse output to JSON facts
-    import_role:
-      name: ansible-network.network-engine
-      tasks_from: cli
-    vars:
-      ansible_network_os: ios
+
+  roles:
+    - name: ansible-network.network-engine
+      function: cli
       command: show version
       parser: parser_templates/ios/show_version.yaml
       engine: command_parser

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,17 @@
 ---
 # tasks file for network-engine
+#
+- name: set role supported functions
+  set_fact:
+    network_engine_functions:
+      - cli
+
+- name: validate the requested function is supported
+  fail:
+    msg: "invalid function specified, expected one of {{ network_engine_functions }}, got {{ function }}"
+  when: function is defined and function not in network_engine_functions
+
+- name: include function specific tasks and run
+  include_tasks: "{{ function }}.yaml"
+  when: function is defined
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,4 +14,3 @@
 - name: include function specific tasks and run
   include_tasks: "{{ function }}.yaml"
   when: function is defined
-


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>
Task as function in main.yaml entrypoint so the generic validations can run for tasks.
