### PR TITLE
makes parser directive extend templatable

### DIFF
--- a/action_plugins/command_parser.py
+++ b/action_plugins/command_parser.py
@@ -113,6 +113,8 @@ class ActionModule(ActionBase):
 
                 register = task.pop('register', None)
                 extend = task.pop('extend', None)
+                if extend:
+                    extend = self.template(extend, self.ds)
 
                 export = task.pop('export', False)
                 export_as = task.pop('export_as', 'list')


### PR DESCRIPTION
This change will now attempt to template the extend keyword when it is
found in parser templates.  If the keyword is static, it is just
returned unchanged.