### PR TITLE
Fix native type conversion in json_template

### DIFF
--- a/action_plugins/command_parser.py
+++ b/action_plugins/command_parser.py
@@ -380,7 +380,7 @@ class ActionModule(ActionBase):
     def _process_directive(self, task):
         for directive, args in iteritems(task):
             if directive == 'block':
-                display.deprecated('`block` is not longer supported, use `pattern_group` instead')
+                display.deprecated('`block` is not longer supported, use `pattern_group` instead', version=2.6)
                 directive = 'pattern_group'
 
             if directive not in self.VALID_DIRECTIVES:

--- a/docs/directives/parser_directives.md
+++ b/docs/directives/parser_directives.md
@@ -241,6 +241,11 @@ The following arguments are supported for this directive:
 
 * `template`
 
+
+**Note**
+Native jinja2 datatype (eg. 'int', 'float' etc.) rendering is supported with Ansible version >= 2.7
+and jinja2 library version >= 2.10
+
 ### `set_vars`
 
 Use the `set_vars` directive to set variables to the values like key / value pairs

--- a/docs/directives/parser_directives.md
+++ b/docs/directives/parser_directives.md
@@ -244,7 +244,32 @@ The following arguments are supported for this directive:
 
 **Note**
 Native jinja2 datatype (eg. 'int', 'float' etc.) rendering is supported with Ansible version >= 2.7
-and jinja2 library version >= 2.10
+and jinja2 library version >= 2.10. To enable native jinja2 config add below configuration in active
+ansible configuration file.
+```
+[defaults]
+jinja2_native= True
+```
+
+Usage example:
+```yaml
+  - set_fact:
+      count: "1"
+
+  - name: print count
+    debug:
+      msg: "{{ count|int }}"
+```
+
+With jinja2_native configuration enabled the output of above example task will have
+```
+"msg": 1
+```
+
+and with jinja2_native configuration disabled (default) output of above example task will have
+```
+"msg": "1"
+```
 
 ### `set_vars`
 

--- a/lib/network_engine/plugins/template/__init__.py
+++ b/lib/network_engine/plugins/template/__init__.py
@@ -43,23 +43,12 @@ class TemplateBase(object):
             self._templar.set_available_variables(variables)
             try:
                 resp = self._templar.template(data, convert_bare=convert_bare)
-                resp = self._coerce_to_native(resp)
             except AnsibleUndefinedVariable:
                 resp = None
                 pass
             finally:
                 self._templar.set_available_variables(tmp_avail_vars)
             return resp
-
-    def _coerce_to_native(self, value):
-        if not isinstance(value, bool):
-            try:
-                value = int(value)
-            except Exception:
-                if value is None or len(value) == 0:
-                    return None
-                pass
-        return value
 
     def _update(self, d, u):
         for k, v in iteritems(u):

--- a/tests/json_template/json_template/tasks/json_lookup.yaml
+++ b/tests/json_template/json_template/tasks/json_lookup.yaml
@@ -8,6 +8,6 @@
       - "'GigabitEthernet0/0' in result.msg"
       - "'config' in result['msg']['GigabitEthernet0/0']"
       - "'Configured by Ansible' in result['msg']['GigabitEthernet0/0']['config']['description']"
-      - "result['msg']['GigabitEthernet0/0']['config']['mtu'] == 1500"
+      - "result['msg']['GigabitEthernet0/0']['config']['mtu'] == '1500'"
       - "'iGbE' in result['msg']['GigabitEthernet0/0']['config']['type']"
       - "'GigabitEthernet0/0' in result['msg']['GigabitEthernet0/0']['config']['name']"


### PR DESCRIPTION
Fixes #151 

*  The current `json_template` implementation tries to convert the value to int irrespective to the 
    actual type of data.

*  Ansible version 2.7 onwards supports native jinja2 types conversion. Refer https://github.com/ansible-network/network-engine/issues/151#issuecomment-427561789
   `eg: value: "{{ item.name.acl_name|float }}"`
   
*  To convert to native jinja2 type by default need to set `jinja2_native` config varaible in `defaults` 
    section of active Ansible config file.
  
`Note: This feature require jinja2 version to be >= 2.10`