### PR TITLE
Set ansible-test-sanity non-voting

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,14 +1,13 @@
 - project:
     check:
       jobs:
-        - ansible-test-sanity
+        - ansible-test-sanity:
+            voting: False
         - ansible-role-tests-devel-py2
         - ansible-role-tests-2.7-py2
         - ansible-role-tests-2.7-py3
     gate:
       jobs:
-        # inverted Python version compared to `check`
-        - ansible-test-sanity
         - ansible-role-tests-devel-py3
         - ansible-role-tests-2.7-py2
         - ansible-role-tests-2.7-py3


### PR DESCRIPTION
Due to an upstream bug with ansible-sanity, it is breaking out jobs.
For now, we can make this non-voting, until upstream has fixed it.

It is better to do this, then force merge code behind zuul.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>