### PR TITLE
Refresh tox.ini settings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,24 @@
 [tox]
-minversion = 1.4.2
-envlist = docs,linters
+minversion = 1.6
 skipsdist = True
+envlist = linters
 
 [testenv]
+basepython = python3
+install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
+
+[testenv:linters]
+commands =
+  flake8 {posargs}
 
 [testenv:venv]
 commands = {posargs}
 
 [flake8]
+# TODO(pabelanger): Follow sane flake8 rules for galaxy and sync across all of
+# ansible-network.
+ignore = E125,E129,E402,E722,F401,F841,H
+max-line-length = 160
 show-source = True
-ignore = E305,E402,E501,E722,E741,W503
-builtins = _
-exclude=.venv,.git,.tox,dist,doc,*egg,build
-
-[testenv:linters]
-setenv =
-  ANSIBLE_ROLES_PATH = ..
-whitelist_externals = bash
-commands =
-  # PEP8 Lint Check
-  flake8
+exclude = .venv,.tox,dist,doc,build,*.egg


### PR DESCRIPTION
Import latest tox.ini settings for network-engine. Right now this is a
manual process, but I plan on writing automation to make this easier
across all our roles.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>