### PR TITLE
Fix E722 do not use bare except warning

### DIFF
--- a/action_plugins/cli.py
+++ b/action_plugins/cli.py
@@ -118,7 +118,7 @@ class ActionModule(ActionBase):
         # try to convert the cli output to native json
         try:
             json_data = json.loads(output)
-        except:
+        except Exception:
             json_data = None
 
         result['json'] = json_data

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands = {posargs}
 [flake8]
 # TODO(pabelanger): Follow sane flake8 rules for galaxy and sync across all of
 # ansible-network.
-ignore = E125,E129,E402,E722,F401,F841,H
+ignore = E125,E129,E402,F401,F841,H
 max-line-length = 160
 show-source = True
 exclude = .venv,.tox,dist,doc,build,*.egg


### PR DESCRIPTION
This updates our cli action plug so we can start gating on E722 flake8
warnings.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>