### PR TITLE
Clean up F841,H flake8 warnings

### DIFF
--- a/lookup_plugins/network_template.py
+++ b/lookup_plugins/network_template.py
@@ -46,10 +46,6 @@ from ansible.errors import AnsibleError, AnsibleUndefinedVariable
 class LookupModule(LookupBase):
 
     def run(self, terms, variables, **kwargs):
-
-        convert_data_p = kwargs.get('convert_data', True)
-        lookup_template_vars = kwargs.get('template_vars', {})
-
         self.ds = variables.copy()
 
         config_lines = list()
@@ -61,14 +57,11 @@ class LookupModule(LookupBase):
             display.vvvv("File lookup using %s as file" % lookupfile)
 
             if lookupfile:
-                with open(to_bytes(lookupfile, errors='surrogate_or_strict'), 'rb') as f:
-                    template_data = to_text(f.read(), errors='surrogate_or_strict')
-
+                with open(to_bytes(lookupfile, errors='surrogate_or_strict'), 'rb'):
                     tasks = self._loader.load_from_file(lookupfile)
 
                     for task in tasks:
-                        name = task.pop('name', None)
-
+                        task.pop('name', None)
                         register = task.pop('register', None)
 
                         when = task.pop('when', None)
@@ -120,9 +113,8 @@ class LookupModule(LookupBase):
 
         for entry in block:
             task = entry.copy()
-
-            name = task.pop('name', None)
-            register = task.pop('register', None)
+            task.pop('name', None)
+            task.pop('register', None)
 
             when = task.pop('when', None)
             if when is not None:

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands = {posargs}
 [flake8]
 # TODO(pabelanger): Follow sane flake8 rules for galaxy and sync across all of
 # ansible-network.
-ignore = E125,E129,E402,F401,F841,H
+ignore = E125,E129,E402,F401
 max-line-length = 160
 show-source = True
 exclude = .venv,.tox,dist,doc,build,*.egg


### PR DESCRIPTION
This fixes the following warnings:
  F841 local variable '...' is assigned to but never used

We can also remove H here too, it doesn't break anything.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>