### PR TITLE
Add py27 / py36 entry points for testing

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,11 +3,9 @@
       jobs:
         - ansible-test-sanity:
             voting: False
-        - ansible-role-tests-devel-py2
-        - ansible-role-tests-2.7-py2
-        - ansible-role-tests-2.7-py3
+        - tox-py27
+        - tox-py36
     gate:
       jobs:
-        - ansible-role-tests-devel-py3
-        - ansible-role-tests-2.7-py2
-        - ansible-role-tests-2.7-py3
+        - tox-py27
+        - tox-py36

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+ansible
 textfsm

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,15 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = linters
+envlist = linters,py27,py36
 
 [testenv]
 install_command = pip install {opts} {packages}
-deps = -r{toxinidir}/test-requirements.txt
+commands =
+  ansible-playbook -i tests/inventory tests/test.yml
+deps =
+  -r{toxinidir}/requirements.txt
+  -r{toxinidir}/test-requirements.txt
 
 [testenv:linters]
 basepython = python3


### PR DESCRIPTION
This will replace our current ansible-role-test jobs, using tox as our
entry point.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>