### PR TITLE
Only set testenv:linters to python3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ skipsdist = True
 envlist = linters
 
 [testenv]
-basepython = python3
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
 
 [testenv:linters]
+basepython = python3
 commands =
   flake8 {posargs}
 


### PR DESCRIPTION
It is possible a testenv could run on centos-7, which doesn't have
python3 by default. So only force the default for our linters, which run
on fedora.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>