### PR TITLE
Add py27 / py36 entry points for testing

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,10 +3,9 @@
       jobs:
         - ansible-test-sanity:
             voting: False
-        - ansible-role-tests-2.6-py2
-        - ansible-role-tests-2.6-py3
+        - tox-py27
+        - tox-py36
     gate:
       jobs:
-        # inverted Python version compared to `check`
-        - ansible-role-tests-2.6-py2
-        - ansible-role-tests-2.6-py3
+        - tox-py27
+        - tox-py36

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+ansible<2.7.0
 textfsm

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,15 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = linters
+envlist = linters,py27,py36
 
 [testenv]
 install_command = pip install {opts} {packages}
-deps = -r{toxinidir}/test-requirements.txt
+commands =
+  ansible-playbook -i tests/inventory tests/test.yml
+deps =
+  -r{toxinidir}/requirements.txt
+  -r{toxinidir}/test-requirements.txt
 
 [testenv:linters]
 basepython = python3


### PR DESCRIPTION
We can start to refactor our ansible-roles-test jobs and replace it with
native tox-py27 and tox-py36 jobs from zuul. This also give the added
bonus for a user to run them locally if they'd like

(cherry picked from commit 7e5ee4841123e177cc6d5e7d095ed5c64f5845bc)
Signed-off-by: Paul Belanger <pabelanger@redhat.com>