### PR TITLE
Add py27 / py36 entry points for testing

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -2,10 +2,10 @@
     check:
       jobs:
         - ansible-test-sanity
-        - ansible-role-tests-2.5-py2
-        - ansible-role-tests-2.5-py3
+        - tox-py27
+        - tox-py36
     gate:
       jobs:
         - ansible-test-sanity
-        - ansible-role-tests-2.5-py2
-        - ansible-role-tests-2.5-py3
+        - tox-py27
+        - tox-py36

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+ansible<2.6.0
 pyang
 textfsm

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,15 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = linters
+envlist = linters,py27,py36
 
 [testenv]
 install_command = pip install {opts} {packages}
-deps = -r{toxinidir}/test-requirements.txt
+commands =
+  ansible-playbook -i tests/inventory tests/test.yml
+deps =
+  -r{toxinidir}/requirements.txt
+  -r{toxinidir}/test-requirements.txt
 
 [testenv:linters]
 basepython = python3


### PR DESCRIPTION
We can start to refactor our ansible-roles-test jobs and replace it with
native tox-py27 and tox-py36 jobs from zuul. This also give the added
bonus for a user to run them locally if they'd like

(cherry picked from commit 7e5ee4841123e177cc6d5e7d095ed5c64f5845bc)
Signed-off-by: Paul Belanger <pabelanger@redhat.com>