### PR TITLE
Move in-tree tox jobs into ansible-zuul-jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,9 +3,3 @@
       jobs:
         - ansible-test-sanity:
             voting: False
-        - tox-py27
-        - tox-py36
-    gate:
-      jobs:
-        - tox-py27
-        - tox-py36


### PR DESCRIPTION
Move these to a central repo, so we can better manage jobs across
branches. We'll leave ansible-sanity for now.

(cherry picked from commit 6f455c63ab8698bb5f6265207321b7a8c5a39363)
Signed-off-by: Paul Belanger <pabelanger@redhat.com>