### PR TITLE
Add ARA support for tox tests

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,4 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see http://docs.openstack.org/infra/bindep/ for additional information.
+
+gcc-c++ [test platform:rpm]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
+ara
 flake8

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ commands =
 deps =
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt
+setenv =
+  ANSIBLE_CALLBACK_PLUGINS = {envsitepackagesdir}/ara/plugins/callbacks
 
 [testenv:linters]
 basepython = python3


### PR DESCRIPTION
It is helpful to give users ARA to look at.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>
(cherry picked from commit cd224575bf00f60f9fe4df21d9ff17f06c844bc8)