### PR TITLE
added name parameter to take in and pass to textfsm_parser

### DIFF
--- a/action_plugins/cli.py
+++ b/action_plugins/cli.py
@@ -98,6 +98,7 @@ class ActionModule(ActionBase):
             command = self._task.args['command']
             parser = self._task.args.get('parser')
             engine = self._task.args.get('engine', 'command_parser')
+            key_name = self._task.args.get('key_name')
         except KeyError as exc:
             raise AnsibleError(to_text(exc))
 
@@ -130,7 +131,8 @@ class ActionModule(ActionBase):
             new_task = self._task.copy()
             new_task.args = {
                 'file': parser,
-                'content': (json_data or output)
+                'content': (json_data or output),
+                'name': key_name,
             }
 
             kwargs = {


### PR DESCRIPTION
Allows you to pass key_name to cli module and pass it to textfsm_parser so it has a name to put it's facts under ansible_facts.  I opened a PR on cisco_ios to address this also.
https://github.com/ansible-network/cisco_ios/pull/50