### PR TITLE
adding name option for textfsm to create facts to key

### DIFF
--- a/action_plugins/cli.py
+++ b/action_plugins/cli.py
@@ -98,7 +98,7 @@ class ActionModule(ActionBase):
             command = self._task.args['command']
             parser = self._task.args.get('parser')
             engine = self._task.args.get('engine', 'command_parser')
-            key_name = self._task.args.get('key_name')
+            name = self._task.args.get('name')
         except KeyError as exc:
             raise AnsibleError(to_text(exc))
 
@@ -132,7 +132,7 @@ class ActionModule(ActionBase):
             new_task.args = {
                 'file': parser,
                 'content': (json_data or output),
-                'name': key_name,
+                'name': name,
             }
 
             kwargs = {

--- a/action_plugins/cli.py
+++ b/action_plugins/cli.py
@@ -98,6 +98,7 @@ class ActionModule(ActionBase):
             command = self._task.args['command']
             parser = self._task.args.get('parser')
             engine = self._task.args.get('engine', 'command_parser')
+            key_name = self._task.args.get('key_name')
         except KeyError as exc:
             raise AnsibleError(to_text(exc))
 
@@ -130,7 +131,8 @@ class ActionModule(ActionBase):
             new_task = self._task.copy()
             new_task.args = {
                 'file': parser,
-                'content': (json_data or output)
+                'content': (json_data or output),
+                'name': key_name,
             }
 
             kwargs = {


### PR DESCRIPTION
Adding name option for textfsm so it has a key to set ansible_facts to.  This is related to changes to ansible-network.cisco_ios, found here, https://github.com/ansible-network/cisco_ios/pull/51

Signed-off-by: jwoogee <jswoods1@gmail.com>