### PR TITLE
Document name option for textfsm in cli plugin and update cli task

### DIFF
--- a/action_plugins/command_parser.py
+++ b/action_plugins/command_parser.py
@@ -17,6 +17,7 @@ from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_text
 from ansible.errors import AnsibleError
+from ansible.utils.display import Display
 
 try:
     from ansible.module_utils.network.common.utils import to_list
@@ -28,12 +29,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.path.pardir, 'lib'
 from network_engine.plugins import template_loader, parser_loader
 from network_engine.utils import dict_merge
 
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+display = Display()
 
 
 def warning(msg):

--- a/action_plugins/validate_role_spec.py
+++ b/action_plugins/validate_role_spec.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 ---
 module: validate_role_spec
-author: Ansible Network Team
+author: Peter Sprygada (@privateip
 short_description: Validate required arguments are set from facts
 description:
   - This module will accept an external argument spec file that will be used to
@@ -46,12 +46,9 @@ from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils import basic
 from ansible.errors import AnsibleModuleError
+from ansible.utils.display import Display
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+display = Display()
 
 
 class ActionModule(ActionBase):

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,6 @@ network_engine_parser: "{{ parser | default(None) }}"
 
 # engine to use for parsing output to JSON facts
 network_engine_engine: "{{ engine | default('command_parser') }}"
+
+# name to display facts for textfsm_parser
+network_engine_name: "{{ name | default(None) }}"

--- a/library/command_parser.py
+++ b/library/command_parser.py
@@ -44,7 +44,7 @@ options:
         the input to the text parser for generating the JSON data.
     required: true
 author:
-  - Ansible Network Team
+  - Peter Sprygada (@privateip)
 '''
 
 EXAMPLES = '''

--- a/library/textfsm_parser.py
+++ b/library/textfsm_parser.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: textfsm_parser
-author: Ansible Network Team
+author: Peter Sprygada (@privateip)
 short_description: Parses text into JSON facts using TextFSM
 description:
   - Provides textfsm rule based templates to parse data from text.

--- a/tasks/cli.yaml
+++ b/tasks/cli.yaml
@@ -7,3 +7,4 @@
     command: "{{ network_engine_command }}"
     parser: "{{ network_engine_parser | default(omit) }}"
     engine: "{{ network_engine_engine | default(omit) }}"
+    name: "{{ network_engine_name | default(omit) }}"


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

Update cli task as `name` is introduced in the PR https://github.com/ansible-network/network-engine/pull/202 for textfsm_parser engine to display ansible_facts with cli plugin.