### PR TITLE
Remove .zuul.yaml

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,5 +1,0 @@
-- project:
-    check:
-      jobs:
-        - ansible-test-sanity:
-            voting: False

--- a/bindep.txt
+++ b/bindep.txt
@@ -2,6 +2,6 @@
 # see http://docs.openstack.org/infra/bindep/ for additional information.
 
 gcc-c++ [test platform:rpm]
-python3-devel [test platform:rpm]
-python3 [test platform:rpm]
-python36 [test !platform:fedora-28]
+python3-devel [test !platform:centos-7 platform:rpm]
+python3 [test !platform:centos-7 platform:rpm]
+python36 [test !platform:centos-7 !platform:fedora-28]


### PR DESCRIPTION
We've moved all jobs to ansible-network/zuul-config.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>