### PR TITLE
fail validate_role_spec plugin if argument_spec is undefined

### DIFF
--- a/action_plugins/validate_role_spec.py
+++ b/action_plugins/validate_role_spec.py
@@ -80,7 +80,7 @@ class ActionModule(ActionBase):
         spec = self._loader.load_from_file(spec_fp)
 
         if 'argument_spec' not in spec:
-            spec.update({'argument_spec': {}})
+            return {'failed': True, 'msg': 'missing required field in specification file: argument_spec'}
 
         argument_spec = spec['argument_spec']
 

--- a/tests/validate_role_spec/validate_role_spec/meta/failedtest.yaml
+++ b/tests/validate_role_spec/validate_role_spec/meta/failedtest.yaml
@@ -1,0 +1,3 @@
+---
+mutually_exclusive:
+  - ['int_arg', 'missing_arg']

--- a/tests/validate_role_spec/validate_role_spec/tasks/main.yaml
+++ b/tests/validate_role_spec/validate_role_spec/tasks/main.yaml
@@ -5,3 +5,6 @@
 
 - name: validate_role_spec test
   import_tasks: validate_role_spec.yaml
+
+- name: validate_role_spec failed test
+  import_tasks: validate_role_spec_failed.yaml

--- a/tests/validate_role_spec/validate_role_spec/tasks/validate_role_spec.yaml
+++ b/tests/validate_role_spec/validate_role_spec/tasks/validate_role_spec.yaml
@@ -5,5 +5,6 @@
     bool_arg: true
     optional_arg: value
 
-- validate_role_spec:
+- name: test validate_role_spec
+  validate_role_spec:
     spec: test.yaml

--- a/tests/validate_role_spec/validate_role_spec/tasks/validate_role_spec_failed.yaml
+++ b/tests/validate_role_spec/validate_role_spec/tasks/validate_role_spec_failed.yaml
@@ -1,0 +1,11 @@
+---
+- name: test failed validate_role_spec
+  validate_role_spec:
+    spec: failedtest.yaml
+  ignore_errors: true
+  register: result
+
+- assert:
+    that:
+      - "result.failed == true"
+      - "'missing required field in specification file: argument_spec' in result.msg"


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

Fail `validate_role_spec` plugin if `argument_spec` is undefined in specification file.
With no argument_spec being defined `AnsibleModule class` doesn't run any validation for other conditions and fail.