### PR TITLE
Fix relative path failure in command_parser

### DIFF
--- a/action_plugins/command_parser.py
+++ b/action_plugins/command_parser.py
@@ -27,7 +27,7 @@ except ImportError:
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.path.pardir, 'lib'))
 from network_engine.plugins import template_loader, parser_loader
-from network_engine.utils import dict_merge
+from network_engine.utils import dict_merge, generate_source_path
 
 display = Display()
 
@@ -92,9 +92,10 @@ class ActionModule(ActionBase):
 
         self.template = template_loader.get('json_template', self._templar)
 
+        paths = self._task.get_search_path()
         for src in sources:
-            src_path = os.path.expanduser(src)
-            if not os.path.exists(src_path) and not os.path.isfile(src_path):
+            src_path = generate_source_path(paths, src)
+            if src_path is None:
                 raise AnsibleError("src [%s] is either missing or invalid" % src_path)
 
             tasks = self._loader.load_from_file(src)

--- a/lib/network_engine/utils.py
+++ b/lib/network_engine/utils.py
@@ -4,10 +4,18 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+import os
+
 from itertools import chain
 
 from ansible.module_utils.six import iteritems
+from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.network.common.utils import sort_list
+from ansible.utils.display import Display
+from ansible.utils.path import unfrackpath
+
+
+display = Display()
 
 
 def dict_merge(base, other):
@@ -73,3 +81,39 @@ def dict_merge(base, other):
         combined[key] = other.get(key)
 
     return combined
+
+
+def generate_source_path(paths, source):
+    """
+    Find file in first path in stack.
+
+    :param paths: A list of text strings which are the path to look for the filename in.
+    :param src: A text string which is the filename to search for.
+    :rtype: A text string.
+    :returns: An absolute path to the filename ``src`` if found.
+    """
+
+    b_source = to_bytes(source)
+
+    result = None
+    search = []
+
+    if source.startswith('~') or source.startswith(os.path.sep):
+        # path is absolute, no relative needed, check existence and return source
+        test_path = unfrackpath(b_source, follow=False)
+        if os.path.exists(to_bytes(test_path, errors='surrogate_or_strict')):
+            result = test_path
+
+    else:
+        for path in paths:
+            upath = unfrackpath(path, follow=False)
+            b_upath = to_bytes(upath, errors='surrogate_or_strict')
+            search.append(os.path.join(b_upath, b_source))
+
+        for candidate in search:
+            display.vvvvv(u'looking for "%s" at "%s"' % (source, to_text(candidate)))
+            if os.path.exists(candidate) and os.path.isfile(candidate):
+                result = to_text(candidate)
+                break
+
+    return result

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 host_key_checking = False
 retry_files_enabled = False
+gathering = explicit


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>
Fixes https://github.com/ansible-network/network-engine/issues/152

**The PR fixes the following issue:**
When playbook is in subdir and it is executed from parent dir, `command_parser` is unable to detect parser template path if the parser template is not present in the playbook dir and relative path for the template is given to `src` param.

**For example:**
tguha@tguha ~/localtest $ tree
```
.
├── ansible.cfg
├── inventory
├── parser_templates
│   └── ios
│       └── show_interfaces.yaml
└── playbooks
    ├── parse.yaml
```

Playbook:
```
  - name: parse interfaces using command_parser engine
    command_parser:
      file: "../parser_templates/ios/show_interfaces.yaml"
      ...
```

Command used: `ansible-playbook playbooks/parse.yaml`