### PR TITLE
Fix for deprecation warning 'set_available_variables is being deprecated'

### DIFF
--- a/lib/network_engine/plugins/template/__init__.py
+++ b/lib/network_engine/plugins/template/__init__.py
@@ -40,14 +40,14 @@ class TemplateBase(object):
         else:
             data = data or {}
             tmp_avail_vars = self._templar._available_variables
-            self._templar.set_available_variables(variables)
+            self._templar.available_variables = variables
             try:
                 resp = self._templar.template(data, convert_bare=convert_bare)
             except AnsibleUndefinedVariable:
                 resp = None
                 pass
             finally:
-                self._templar.set_available_variables(tmp_avail_vars)
+                self._templar.available_variables = tmp_avail_vars
             return resp
 
     def _update(self, d, u):

--- a/lookup_plugins/network_template.py
+++ b/lookup_plugins/network_template.py
@@ -233,14 +233,14 @@ class LookupModule(LookupBase):
         else:
             data = data or {}
             tmp_avail_vars = self._templar._available_variables
-            self._templar.set_available_variables(variables)
+            self._templar.available_variables = variables
             try:
                 resp = self._templar.template(data, convert_bare=convert_bare)
                 resp = self._coerce_to_native(resp)
             except AnsibleUndefinedVariable:
                 resp = None
             finally:
-                self._templar.set_available_variables(tmp_avail_vars)
+                self._templar.available_variables = tmp_avail_vars
             return resp
 
     def _coerce_to_native(self, value):


### PR DESCRIPTION
Fix for [DEPRECATION WARNING]: set_available_variables is being deprecated. Use "@available_variables.setter" instead.. This feature will 
be removed in version 2.13.

Reference: https://github.com/ansible/ansible/pull/55435

Tested with Ansible 2.9.7